### PR TITLE
Fix a few peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@firebase/app-types": "^0.3.2",
     "@material-ui/core": "^1.2.0",
     "@material-ui/icons": "^1.1.0",
     "firebase": "^5.0.4",
     "formik": "^0.11.11",
+    "prop-types": "^15.6.1",
     "raven-js": "^3.25.2",
     "react": "^16.4.0",
     "react-copy-to-clipboard": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@
     core-js "^2.5.3"
     regenerator-runtime "^0.11.1"
 
-"@firebase/app-types@0.3.2":
+"@firebase/app-types@0.3.2", "@firebase/app-types@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.3.2.tgz#a92dc544290e2893bd8c02a81e684dae3d8e7c85"
 


### PR DESCRIPTION
Those warnings when you ran `yarn`. Only one is left now, but that
can't be fixed due to a dependency version conflict between
react-scripts and jest-enzyme. We need to wait for a new version
of react-scripts.