### PR TITLE
Provide a back option in the QR labels screen

### DIFF
--- a/src/pages/CreateLabelsPage.css
+++ b/src/pages/CreateLabelsPage.css
@@ -2,7 +2,27 @@
   size: A4 landscape;
   margin: 5.9mm 0mm 0mm 9.5mm;
 }
-
+@media print {
+  .no-print,
+  .no-print * {
+    display: none !important;
+  }
+}
+.infobox {
+  background-color: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 250px;
+  border-radius: 3px;
+  padding: 10px;
+  font-family: "Open Sans", Helvetica, Arial, sans-serif;
+  font-size: 85%;
+}
+.infobox a {
+  color: #fff;
+}
 .CreateLabelsPage .label {
   background-color: #fff;
   page-break-inside: avoid;

--- a/src/pages/CreateLabelsPage.js
+++ b/src/pages/CreateLabelsPage.js
@@ -31,6 +31,13 @@ class CreateQRLabelsPage extends React.Component {
             <div className="product">product</div>
           </div>
         ))}
+        <div className="infobox no-print">
+          Print these labels on A4-sheets divided in a 2x2 layout. Use a Chrome
+          browser to be sure that the layout prints well.<br />
+          <br />
+          <a href="/dashboard">Go back</a> or{" "}
+          <button onClick="window.print">Print</button>
+        </div>
       </div>
     );
   }

--- a/src/pages/CreateLabelsPage.js
+++ b/src/pages/CreateLabelsPage.js
@@ -35,7 +35,7 @@ class CreateQRLabelsPage extends React.Component {
           Print these labels on A4-sheets divided in a 2x2 layout. Use a Chrome
           browser to be sure that the layout prints well.<br />
           <br />
-          <a href="/dashboard">Go back</a> or{" "}
+          <a href="/dashboard">Go back</a>
         </div>
       </div>
     );

--- a/src/pages/CreateLabelsPage.js
+++ b/src/pages/CreateLabelsPage.js
@@ -36,7 +36,6 @@ class CreateQRLabelsPage extends React.Component {
           browser to be sure that the layout prints well.<br />
           <br />
           <a href="/dashboard">Go back</a> or{" "}
-          <button onClick="window.print">Print</button>
         </div>
       </div>
     );


### PR DESCRIPTION
#136 
I provided the simplest possible solution: an explanation of this screen with a link back to the dashboard.