### PR TITLE
Infobox on Create labels page was broken

### DIFF
--- a/src/pages/CreateLabelsPage.css
+++ b/src/pages/CreateLabelsPage.css
@@ -9,7 +9,7 @@
   }
 }
 
-.CreateLabelsPage .infobox a {
+.CreateLabelsPage .infobox {
   background-color: rgba(0, 0, 0, 0.75);
   color: #fff;
   position: absolute;
@@ -20,6 +20,9 @@
   padding: 10px;
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 85%;
+}
+.CreateLabelsPage .infobox a {
+  color: #fff;
 }
 .CreateLabelsPage .label {
   background-color: #fff;


### PR DESCRIPTION
The help text was displayed outside of the box and only the link back was displayed properly.