### PR TITLE
Copy production configuration before building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,13 @@ node_js:
 - '8'
 cache: yarn
 script:
-- yarn build
 - yarn test
 # .env.production is kept out of the root directory, because if it were there
 # running "firebase deploy" would create a clone of our real production
 # environment. This is not something we can stop (they are public details) but
 # we should at least stop people from doing it accidentally.
-before_deploy:
 - cp .travis/.env.production ./
+- yarn build
 deploy:
   provider: firebase
   project: boxwise-production


### PR DESCRIPTION
Test first without copying so we don't accidentally run tests
in production environment.