### PR TITLE
#23 Added a new page to change user password, and linked it in snackbar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import ProductsPage from "./pages/ProductsPage";
 import CreateOrganizationPage from "./pages/CreateOrganizationPage";
 import SignInPage from "./containers/pages/SignInPage";
 import ResetPasswordPage from "./containers/pages/ResetPasswordPage";
+import PasswordChangePage from "./pages/PasswordChangePage";
 import InvitePage from "./pages/InvitePage";
 import JoinPage from "./pages/JoinPage";
 import MockupsPage from "./pages/MockupsPage";
@@ -68,6 +69,11 @@ const App = () => (
             exact
             path="/reset-password"
             component={() => <ResetPasswordPage />}
+          />
+          <AuthedRoute
+            exact
+            path="/password"
+            component={() => <PasswordChangePage />}
           />
           <Route exact path="/join/:inviteId" component={() => <JoinPage />} />
 

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -13,6 +13,11 @@ export const PASSWORD_RESET_START = PASSWORD_RESET_`START`;
 export const PASSWORD_RESET_SUCCESS = PASSWORD_RESET_`SUCCESS`;
 export const PASSWORD_RESET_ERROR = PASSWORD_RESET_`ERROR`;
 
+const PASSWORD_CHANGE_ = TYPE => `USER_PASSWORD_CHANGE_${TYPE}`;
+export const PASSWORD_CHANGE_START = PASSWORD_CHANGE_`START`;
+export const PASSWORD_CHANGE_SUCCESS = PASSWORD_CHANGE_`SUCCESS`;
+export const PASSWORD_CHANGE_ERROR = PASSWORD_CHANGE_`ERROR`;
+
 export const userSignOut = () => ({ type: USER_SIGN_OUT });
 
 export const firebaseSignOut = () => dispatch => {
@@ -50,5 +55,31 @@ export const resetPassword = ({ email }) => dispatch => {
     .catch(error => {
       handleError(error);
       dispatch({ type: PASSWORD_RESET_ERROR, payload: error });
+    });
+};
+
+export const userPasswordChange = ({
+  email,
+  currentPassword,
+  newPassword
+}) => dispatch => {
+  dispatch({ type: PASSWORD_CHANGE_START });
+  return firebase
+    .auth()
+    .signInWithEmailAndPassword(email, currentPassword)
+    .then(({ user }) =>
+      user
+        .updatePassword(newPassword)
+        .then(() => dispatch({ type: PASSWORD_CHANGE_SUCCESS }))
+        .catch(error => {
+          handleError(error);
+          dispatch({ type: PASSWORD_CHANGE_ERROR, payload: error });
+          throw error;
+        })
+    )
+    .catch(error => {
+      handleError(error);
+      dispatch({ type: PASSWORD_CHANGE_ERROR, payload: error });
+      throw error;
     });
 };

--- a/src/components/AppDrawerAuth.js
+++ b/src/components/AppDrawerAuth.js
@@ -12,6 +12,7 @@ const AppDrawerAuth = ({
   user,
   profile,
   onSignOut,
+  onPasswordChange,
   onClose
 }) => {
   if (loading) {
@@ -33,6 +34,9 @@ const AppDrawerAuth = ({
       </ListItem>
       <ListItem component={Link} to="/invite" onClick={onClose} button>
         <ListItemText primary="Invite people" />
+      </ListItem>
+      <ListItem component={Link} to="/password" onClick={onClose} button>
+        <ListItemText primary="Change password" />
       </ListItem>
       <ListItem button>
         <ListItemText primary="Sign out" onClick={onSignOut} />

--- a/src/components/PasswordChangeForm.js
+++ b/src/components/PasswordChangeForm.js
@@ -1,0 +1,140 @@
+import React from "react";
+import { Field, Formik } from "formik";
+import { withStyles } from "@material-ui/core/styles";
+import TextField from "../vendor/formik-material-ui/TextField";
+import Typography from "@material-ui/core/Typography";
+import ButtonWithProgress from "./ButtonWithProgress";
+import { handleError } from "../utils";
+
+const styles = theme => ({
+  submit: {
+    marginTop: theme.spacing.unit * 2
+  }
+});
+
+const PasswordChangeForm = ({ classes, user, userPasswordChange }) => (
+  <Formik
+    initialValues={{
+      currentPassword: "",
+      newPassword: "",
+      confirmedPassword: ""
+    }}
+    validate={values => {
+      let errors = {};
+      if (!values.currentPassword) {
+        errors.currentPassword = "Enter your current password.";
+      }
+      if (!values.newPassword) {
+        errors.newPassword = "Enter your new password.";
+      }
+      if (!values.confirmedPassword) {
+        errors.confirmedPassword = "Confirmed your new password.";
+      }
+      if (values.newPassword !== values.confirmedPassword) {
+        errors.mismatchedPassword =
+          "The confirmed password is different from the new password.";
+      } else if (values.newPassword.length < 6) {
+        errors.malformedPassword = "Password should be at least 6 characters.";
+      }
+
+      return errors;
+    }}
+    onSubmit={(
+      { currentPassword, newPassword },
+      { setSubmitting, setErrors, setStatus }
+    ) => {
+      const email = user.data.email;
+      userPasswordChange({ email, currentPassword, newPassword })
+        .then(() => {
+          setSubmitting(false);
+          setStatus(0);
+        })
+        .catch(error => {
+          setSubmitting(false);
+          handleError(error);
+          setErrors({ form: error.message });
+        });
+    }}
+    render={({ handleSubmit, isSubmitting, errors, touched, status }) => (
+      <form onSubmit={handleSubmit}>
+        {status === 0 ? (
+          <Typography variant="body1" color="primary">
+            Your password has been updated successfully.
+          </Typography>
+        ) : null}
+
+        {/* TODO: style errors */}
+        {errors.form ? (
+          <Typography variant="body1" color="error">
+            {errors.form}
+          </Typography>
+        ) : null}
+
+        {touched.currentPassword && errors.currentPassword ? (
+          <Typography variant="body1" color="error">
+            {errors.currentPassword}
+          </Typography>
+        ) : null}
+        <Field
+          type="password"
+          label="Current Password"
+          name="currentPassword"
+          component={TextField}
+          fullWidth
+          margin="normal"
+        />
+        {touched.newPassword && errors.newPassword ? (
+          <Typography variant="body1" color="error">
+            {errors.newPassword}
+          </Typography>
+        ) : null}
+        <Field
+          type="password"
+          label="New Password"
+          name="newPassword"
+          component={TextField}
+          fullWidth
+          margin="normal"
+        />
+        {touched.confirmedPassword && errors.confirmedPassword ? (
+          <Typography variant="body1" color="error">
+            {errors.confirmedPassword}
+          </Typography>
+        ) : null}
+        <Field
+          type="password"
+          label="Confirm Password"
+          name="confirmedPassword"
+          component={TextField}
+          fullWidth
+          margin="normal"
+        />
+        {touched.newPassword &&
+        touched.confirmedPassword &&
+        errors.mismatchedPassword ? (
+          <Typography variant="body1" color="error">
+            {errors.mismatchedPassword}
+          </Typography>
+        ) : null}
+        {touched.newPassword &&
+        touched.confirmedPassword &&
+        errors.malformedPassword ? (
+          <Typography variant="body1" color="error">
+            {errors.malformedPassword}
+          </Typography>
+        ) : null}
+        <ButtonWithProgress
+          variant="raised"
+          color="primary"
+          type="submit"
+          loading={isSubmitting || user.isUpdating}
+          className={classes.submit}
+        >
+          Update Password
+        </ButtonWithProgress>
+      </form>
+    )}
+  />
+);
+
+export default withStyles(styles)(PasswordChangeForm);

--- a/src/containers/components/PasswordChangeForm.js
+++ b/src/containers/components/PasswordChangeForm.js
@@ -1,0 +1,10 @@
+import { connect } from "react-redux";
+import { userPasswordChange } from "../../actions/auth";
+import PasswordChangeForm from "../../components/PasswordChangeForm";
+
+const mapStateToProps = ({ user }) => ({ user });
+const mapDispatchToProps = { userPasswordChange };
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PasswordChangeForm);

--- a/src/containers/pages/PasswordChangeForm.js
+++ b/src/containers/pages/PasswordChangeForm.js
@@ -1,0 +1,6 @@
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import PasswordChangePage from "../../pages/PasswordChangePage";
+
+const mapStateToProps = ({ user }) => ({ user });
+export default connect(mapStateToProps)(withRouter(PasswordChangePage));

--- a/src/pages/PasswordChangePage.js
+++ b/src/pages/PasswordChangePage.js
@@ -1,0 +1,14 @@
+import React from "react";
+import AppFrame from "../components/AppFrame";
+import Page from "../components/Page";
+import PasswordChangeForm from "../containers/components/PasswordChangeForm";
+
+const PasswordChangePage = () => (
+  <AppFrame title="Change Your Password">
+    <Page>
+      <PasswordChangeForm />
+    </Page>
+  </AppFrame>
+);
+
+export default PasswordChangePage;

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -5,7 +5,10 @@ import {
   USER_SIGN_OUT,
   PASSWORD_RESET_START,
   PASSWORD_RESET_SUCCESS,
-  PASSWORD_RESET_ERROR
+  PASSWORD_RESET_ERROR,
+  PASSWORD_CHANGE_START,
+  PASSWORD_CHANGE_SUCCESS,
+  PASSWORD_CHANGE_ERROR
 } from "../actions/auth";
 
 export default function user(
@@ -38,6 +41,15 @@ export default function user(
         hasTriggeredReset: false,
         error: payload
       };
+
+    case PASSWORD_CHANGE_START:
+      return { ...state, isUpdating: true, error: null };
+
+    case PASSWORD_CHANGE_SUCCESS:
+      return { ...state, isUpdating: false, error: null };
+
+    case PASSWORD_CHANGE_ERROR:
+      return { ...state, isUpdating: false, error: payload };
 
     default:
       return state;


### PR DESCRIPTION
Some key things I added:
1. added basic password validation and client-side error reporting on validation failure
2. do a sign in operation with user's existing email first, then immediately update user's password (firebase requires user to be recently signed in)
3. display success or failure message at the top of the password change page after user submit the request