### PR TITLE
Script to set up a bunch of test data in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "postcheckout": "node checkdeploy",
     "postrewrite": "node checkdeploy",
     "setup": "node utils/generate-env.js",
+    "add-test-data": "node utils/generate-test-data.js",  
     "cypress:open": "cypress open"
   },
   "lint-staged": {

--- a/utils/generate-test-data.js
+++ b/utils/generate-test-data.js
@@ -27,6 +27,7 @@ const schema = {
     properties: {
         email: {
             required: true,
+            message: 'Enter your email for signin',
         },
         password: {
             hidden: true,
@@ -34,6 +35,7 @@ const schema = {
         },
         organization_name: {
             required: true,
+            message: 'Enter the name of your test organization',
         },
     }
 };
@@ -45,6 +47,7 @@ var email = "testuser@boxwise.co";
 var password = "password3";
 
 function readConfig() {
+    console.log("Reading local firebase configuration");
     const file = resolve(process.cwd(), `.env.local`);
     return readFile(file, 'utf8');
 }
@@ -84,6 +87,8 @@ const setupAuth = () => {
 };
 
 const addOrganization = ({ name }) => {
+    console.log("Creating organization " + name);
+    
     return firestore.collection("organizations").add({
         name: name,
         createdAt: firebase.firestore.FieldValue.serverTimestamp()
@@ -142,6 +147,8 @@ const addProduct = (values, uid) => {
 };
 
 const generateProducts = (profile_id) => {
+
+    console.log("Creating test products");
     const promises = [];
 
     const categories = ['Man', 'Woman', 'Adult', 'Boy', 'Girl', 'Child', 'Baby', 'Food', 'Hygiene', 'Other'];
@@ -160,6 +167,8 @@ const generateProducts = (profile_id) => {
 };
 
 const generateBoxes = (products) => {
+    console.log("Creating test boxes");
+    
     const promises = [];
     
     for(let i = 0; i < 5; i++) {

--- a/utils/generate-test-data.js
+++ b/utils/generate-test-data.js
@@ -1,0 +1,180 @@
+var firebase = require('firebase/app');
+
+var auth = require("firebase/auth");
+var firestore2 = require("firebase/firestore");
+
+// TODO import this from .env.local
+const REACT_APP_FIREBASE_API_KEY="AIzaSyDBtbOWhMSbVQLw_QJ1ohgucUrlA_ODkCo";
+const REACT_APP_FIREBASE_AUTH_DOMAIN="boxwise-development-de322.firebaseapp.com";
+const REACT_APP_FIREBASE_DATABASE_URL="https://boxwise-development-de322.firebaseio.com";
+const REACT_APP_FIREBASE_PROJECT_ID="boxwise-development-de322";
+const REACT_APP_FIREBASE_STORAGE_BUCKET="";
+const REACT_APP_FIREBASE_MESSAGING_SENDER_ID="7668499136";
+    
+const config = {
+  apiKey: REACT_APP_FIREBASE_API_KEY,
+  authDomain: REACT_APP_FIREBASE_AUTH_DOMAIN,
+  databaseURL: REACT_APP_FIREBASE_DATABASE_URL,
+  projectId: REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: REACT_APP_FIREBASE_MESSAGING_SENDER_ID
+};
+
+const handleError = (error, errorInfo) => {
+  console.error(error);
+  console.error(errorInfo);
+};
+
+const handleSuccess = (data) => {
+  console.error(data);
+};
+
+
+if (!firebase.apps.length) {
+  firebase.initializeApp(config);
+}
+
+firestore = firebase.firestore();
+firestore.settings({ timestampsInSnapshots: true });
+
+
+var organization_id = null;
+
+var profile_id = null;
+
+var email = "bwaite+55551@tripadvisor.com";
+
+var password = "password3";
+
+const setupAuth = () => {
+ return firebase
+    .auth()
+    .signInWithEmailAndPassword(email, password);
+};
+
+const addOrganization = ({ name }) => {
+  return firestore.collection("organizations").add({
+    name: name,
+    createdAt: firebase.firestore.FieldValue.serverTimestamp()
+  });
+};
+
+const addBox = (product_id) => {
+    const values = { quantity: 8, comment: "test comment"};
+
+    values.createdAt = firebase.firestore.FieldValue.serverTimestamp();
+    values.createdBy = firestore.doc("profiles/" + profile_id);
+    values.organization = firestore.doc("organizations/" + organization_id); // firestore.doc(profile.data.organization.ref);
+    //humanID: 500913
+
+    values.product = firestore.doc( product_id);
+    
+    return firestore
+        .collection("boxes")
+        .add(values);
+};
+
+    
+// TODO
+const setProfile = (uid , data) => {
+  // console.log("UID is: " + uid);
+  // console.log("DATA is: " + data);
+
+    
+  return firestore
+    .collection("profiles")
+    .doc(uid)
+    .set(data);
+};
+
+const createUserAndProfile = ({ email, password }, profile) => {
+  return firebase
+    .auth()
+    .createUserWithEmailAndPassword(email, password)
+        .then(({ user }) => setProfile(user.uid, profile));
+};
+
+const addProduct = (values, uid) => {
+
+    console.log("organizations/" + organization_id);
+    console.log("profiles/" + uid);
+    
+    values.organization = firestore.doc("organizations/" + organization_id); // firestore.doc(profile.data.organization.ref);
+
+    values.createdAt = firebase.firestore.FieldValue.serverTimestamp();
+    values.createdBy = firestore.doc("profiles/" + uid); // firestore.doc(profile.data.ref);
+    values.isDeleted = false;
+    
+    return  firestore
+        .collection("products")
+        .add(values);
+};
+
+
+
+// addOrganization({name: 'bryan test'})
+//     .then( (ref) => {
+//         var res = ref.id;
+//         organization_res = res;
+//         console.log(res);
+//     })
+//     .then( () => { return setupAuth(); })
+//     .then( () => { addProduct( { category: "Woman", name: "test15", }) })
+//     .then(() => { process.exit(); });
+
+// setupAuth()
+//     .then( () => { addOrganization({name: 'bryan test'}); })
+//     .then( (organizations) => {
+//         var res = Promise.resolve(organizations.docs[0].ref);
+//         organization_res = res;
+//     } )
+//     .then(() => { process.exit(); });
+
+
+// Add organization and profile
+console.info("trying to create a test org");
+
+addOrganization({name: 'bryan test 3'})
+     .then( (ref) => {
+         organization_id = ref.id;
+         const orgRef = {organization: firestore.doc('organizations/' + ref.id)};
+         return createUserAndProfile({ email: email, password: password }, orgRef);
+     })
+    .then( () => {
+        return setupAuth();
+    })
+    .catch( (r1) => { console.log(r1); process.exit(); } )
+    .then( ({ user }) => {
+        profile_id = user.uid;
+        
+        return addProduct({
+            category: "Woman",
+            name: "test15",
+        }, user.uid);
+    })
+    .catch( (r1) => { console.log(r1); process.exit(); } )
+    .then( (res) => {
+        let product_id = res._key.path.segments.join('/');
+        return addBox(product_id);
+        
+    } )
+    .then( () => {  process.exit(); });
+
+// Adding products and boxes
+    
+// Good to go !!!    
+// setupAuth()
+//     .then(({ user }) => {
+//         profile_id = user.uid;
+        
+//         return addProduct({
+//             category: "Woman",
+//             name: "test15",
+//         }, user.uid);
+//     })
+    
+ //     .then((res) => {
+//         let product_id = res._key.path.segments.join('/');
+//         return addBox(product_id);
+//     })
+//     .then( () => { process.exit(); });

--- a/utils/generate-test-data.js
+++ b/utils/generate-test-data.js
@@ -1,7 +1,18 @@
+
+const { promisify } = require("util");
+const fs = require("fs");
+const prompt = require("prompt");
+
+
+const get = promisify(prompt.get);
+const readFile = promisify(fs.readFile);
+
+
 var firebase = require('firebase/app');
 
 var auth = require("firebase/auth");
 var firestore2 = require("firebase/firestore");
+
 
 // TODO import this from .env.local
 const REACT_APP_FIREBASE_API_KEY="AIzaSyDBtbOWhMSbVQLw_QJ1ohgucUrlA_ODkCo";
@@ -19,6 +30,12 @@ const config = {
   storageBucket: REACT_APP_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: REACT_APP_FIREBASE_MESSAGING_SENDER_ID
 };
+
+function readConfig() {
+  const file = resolve(process.cwd(), `.env.${env}`);
+  return readFile(file);
+}
+
 
 const handleError = (error, errorInfo) => {
   console.error(error);
@@ -38,6 +55,8 @@ firestore = firebase.firestore();
 firestore.settings({ timestampsInSnapshots: true });
 
 
+  return writeFile(file, content);
+
 var organization_id = null;
 
 var profile_id = null;
@@ -45,6 +64,7 @@ var profile_id = null;
 var email = "bwaite+55551@tripadvisor.com";
 
 var password = "password3";
+
 
 const setupAuth = () => {
  return firebase
@@ -134,7 +154,31 @@ const addProduct = (values, uid) => {
 // Add organization and profile
 console.info("trying to create a test org");
 
-addOrganization({name: 'bryan test 3'})
+
+prompt.start();
+ 
+  //
+  // Get two properties from the user: username and email
+//
+
+const schema = {
+    properties: {
+      email: {
+        required: true
+      },
+      password: {
+        hidden: true
+      }
+    }
+  };
+
+get(schema)
+    .then( (result) => {
+        email = result.email;
+        password = result.password;
+        
+        return addOrganization({name: 'bryan test 3'});
+    })
      .then( (ref) => {
          organization_id = ref.id;
          const orgRef = {organization: firestore.doc('organizations/' + ref.id)};


### PR DESCRIPTION
This should hopefully address issue #24
 
The new generate-test-data.js script will create a new organization with a single user profile, and add 10 randomly generated products and 5 randomly generated boxes to it.

It can be run with `yarn add-test-data` which will prompt the user for the email to use, a password, and the name of the organization to create. After that it will create the data in firestore, and they can log in with the newly created email/password and test things out in the app.