### PR TITLE
Redesign: Drawer and navigation bar

### DIFF
--- a/src/components/AppDrawer.js
+++ b/src/components/AppDrawer.js
@@ -6,7 +6,6 @@ import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import Drawer from "@material-ui/core/Drawer";
 import SwipeableDrawer from "@material-ui/core/SwipeableDrawer";
-import Divider from "@material-ui/core/Divider";
 import Hidden from "@material-ui/core/Hidden";
 import { Link } from "react-router-dom";
 import AppDrawerAuthContainer from "../containers/components/AppDrawerAuth";

--- a/src/components/AppDrawer.js
+++ b/src/components/AppDrawer.js
@@ -38,6 +38,13 @@ const styles = theme => ({
     flexDirection: "column",
     alignItems: "flex-start",
     justifyContent: "center"
+  },
+  menuItem: {
+    paddingTop: 6,
+    paddingBottom: 6
+  },
+  itemGroup: {
+    paddingBottom: 20
   }
 });
 
@@ -67,21 +74,33 @@ const AppDrawer = ({
           </Link>
         </div>
       </div>
-      <List>
-        <ListItem component={Link} to="/" onClick={onClose} button>
+      <List className={classes.itemGroup}>
+        <ListItem component={Link} to="/" onClick={onClose} button className={classes.menuItem}>
           <ListItemText primary="Dashboard" />
         </ListItem>
-        <ListItem component={Link} to="/boxes" onClick={onClose} button>
+        <ListItem component={Link} to="/orders" onClick={onClose} button className={classes.menuItem}>
+          <ListItemText primary="View orders" />
+        </ListItem>
+        <ListItem component={Link} to="/" onClick={onClose} button className={classes.menuItem}>
           <ListItemText primary="Find boxes" />
         </ListItem>
-        <ListItem component={Link} to="/products" onClick={onClose} button>
-          <ListItemText primary="Manage products" />
+        <ListItem component={Link} to="/" onClick={onClose} button className={classes.menuItem}>
+          <ListItemText primary="Make boxes" />
         </ListItem>
-        <ListItem component={Link} to="/create-labels" onClick={onClose} button>
-          <ListItemText primary="Create labels" />
+        <ListItem component={Link} to="/labels" onClick={onClose} button className={classes.menuItem}>
+          <ListItemText primary="Print labels" />
         </ListItem>
       </List>
-      <Divider />
+      
+      <List className={classes.itemGroup}>
+        <ListItem component={Link} to="/" onClick={onClose} button className={classes.menuItem}>
+          <ListItemText primary="Settings" />
+        </ListItem>
+        <ListItem component={Link} to="/" onClick={onClose} button className={classes.menuItem}>
+          <ListItemText primary="Users" />
+        </ListItem>
+      </List>
+
       <AppDrawerAuthContainer onClose={onClose} />
     </div>
   );

--- a/src/components/AppDrawerAuth.js
+++ b/src/components/AppDrawerAuth.js
@@ -5,6 +5,23 @@ import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import Progress from "./Progress.js";
+import { withStyles } from "@material-ui/core/styles";
+
+const styles = theme => ({
+  noPadding: {
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+  smallerTextGroup: {
+    paddingTop: 20,
+    paddingBottom: 20
+  },
+  smallerLink: {
+    '&:hover': {
+      cursor: "pointer"
+    }
+  }
+});  
 
 const AppDrawerAuth = ({
   notAuthenticated,
@@ -13,6 +30,7 @@ const AppDrawerAuth = ({
   profile,
   onSignOut,
   onPasswordChange,
+  classes,
   onClose
 }) => {
   if (loading) {
@@ -25,23 +43,22 @@ const AppDrawerAuth = ({
   const { name, organization } = profile.data;
 
   return (
-    <List>
-      <ListItem>
-        <ListItemText secondary={`Signed in as ${name ? name : email}`} />
-      </ListItem>
-      <ListItem>
-        <ListItemText secondary={`Organization: ${organization.name}`} />
-      </ListItem>
-      <ListItem component={Link} to="/invite" onClick={onClose} button>
-        <ListItemText primary="Invite people" />
-      </ListItem>
-      <ListItem component={Link} to="/password" onClick={onClose} button>
-        <ListItemText primary="Change password" />
-      </ListItem>
-      <ListItem button>
-        <ListItemText primary="Sign out" onClick={onSignOut} />
-      </ListItem>
-    </List>
+    <div>
+      <List className={classes.smallerTextGroup}>
+        <ListItem className={classes.noPadding}>
+          <ListItemText secondary={`Signed in as ${name ? name : email}`} />
+        </ListItem>
+        <ListItem className={classes.noPadding}>
+          <ListItemText secondary={`for ${organization.name}`} />
+        </ListItem>
+      </List>
+
+      <List className={classes.smallerTextGroup}>
+        <ListItem className={classes.noPadding}>
+          <ListItemText secondary="Sign out" className={classes.smallerLink} onClick={onSignOut} />
+        </ListItem>
+      </List>  
+    </div>
   );
 };
 
@@ -53,4 +70,4 @@ AppDrawerAuth.propTypes = {
   onClose: PropTypes.func
 };
 
-export default AppDrawerAuth;
+export default withStyles(styles)(AppDrawerAuth);

--- a/src/components/AppDrawerAuth.js
+++ b/src/components/AppDrawerAuth.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Link } from "react-router-dom";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";

--- a/src/components/AppDrawerAuth.js
+++ b/src/components/AppDrawerAuth.js
@@ -55,7 +55,7 @@ const AppDrawerAuth = ({
 
       <List className={classes.smallerTextGroup}>
         <ListItem className={classes.noPadding}>
-          <ListItemText secondary="Sign out" className={classes.smallerLink} onClick={onSignOut} />
+          <ListItemText secondary="Logout" className={classes.smallerLink} onClick={onSignOut} />
         </ListItem>
       </List>  
     </div>

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -5,6 +5,7 @@ import Typography from "@material-ui/core/Typography";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
 import IconButton from "@material-ui/core/IconButton";
+import SearchIcon from '@material-ui/icons/Search';
 import MenuIcon from "@material-ui/icons/Menu";
 import AppDrawer from "./AppDrawer";
 import { drawerTheme } from "../theme";
@@ -97,6 +98,18 @@ class AppFrame extends React.Component {
               </Typography>
             )}
             <div className={classes.grow} />
+
+            <div> 
+              <IconButton
+                aria-owns={open ? 'menu-appbar' : null}
+                aria-haspopup="true"
+                onClick={this.handleMenu}
+                color="inherit"
+              >
+                <SearchIcon />
+              </IconButton>
+            </div>  
+
           </Toolbar>
         </AppBar>
         <MuiThemeProvider theme={drawerTheme}>

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -52,7 +52,11 @@ const styles = theme => ({
     },
     [theme.breakpoints.up("lg")]: {
       width: "calc(100% - 250px)",
-    }
+    },
+    [theme.breakpoints.only('xs')]: {
+      marginTop: 48,
+    },
+
   },
   secondaryToolbar: {
     height: 30,

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -11,6 +11,8 @@ import MenuIcon from "@material-ui/icons/Menu";
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import AppDrawer from "./AppDrawer";
+import ProductButton from "../components/ProductButton";
+import Grid from '@material-ui/core/Grid';
 import { drawerTheme } from "../theme";
 
 const secondaryBarHeight = 30;
@@ -21,6 +23,9 @@ const styles = theme => ({
     alignItems: "stretch",
     minHeight: "100vh",
     width: "100%"
+  },
+  productRoot: {
+    width: "240px"
   },
   rootLocked: {
     display: "flex",
@@ -68,6 +73,9 @@ const styles = theme => ({
     fontSize: 12,
     color: "#b2e1f3"
   },
+  secondaryMenu: {
+    width: 300
+  },
   drawer: {
     [theme.breakpoints.up("lg")]: {
       width: 250
@@ -88,8 +96,13 @@ const styles = theme => ({
     }
   },
   popupTitle: {
-    margin: "6 4",
-    fontSize: 15
+    margin: "6px 4px",
+    fontSize: 15,
+    fontWeight: "bold",
+    textAlign: "center"
+  },
+  productItem: {
+    margin: "3px"
   }
 });
 
@@ -168,7 +181,7 @@ class AppFrame extends React.Component {
               >
                 Product
               </Button>
-              <Menu
+              <Menu className={classes.secondaryMenu}
                 id="menu-appbar"
                 anchorEl={anchorEl}
                 anchorOrigin={{
@@ -182,10 +195,55 @@ class AppFrame extends React.Component {
                 open={open}
               >
                 <div className={classes.popupTitle}>Choose a category</div>
-                <MenuItem onClick={this.handleClose}>Man</MenuItem>
-                <MenuItem onClick={this.handleClose}>Woman</MenuItem>
-                <MenuItem>Adult</MenuItem>
-                <MenuItem>...</MenuItem>
+                <div className={classes.productRoot}>
+                  <Grid container>
+                    <Grid item xs={4}>
+                      <MenuItem className={classes.productItem}>
+                        <ProductButton icon="" label="Man" />
+                      </MenuItem>
+                    </Grid>
+                    <Grid item xs={4}>
+                      <MenuItem className={classes.productItem}>
+                        <ProductButton icon="" label="Woman" />
+                      </MenuItem>  
+                    </Grid>
+                    <Grid item xs={4}>
+                      <MenuItem className={classes.productItem}>
+                        <ProductButton icon="" label="Adult" />
+                      </MenuItem>  
+                    </Grid>
+                    <Grid item xs={4}>  
+                      <MenuItem className={classes.productItem}>
+                        <ProductButton icon="" label="Boy" />
+                      </MenuItem>  
+                    </Grid>
+                    <Grid item xs={4}>  
+                      <MenuItem className={classes.productItem}>
+                        <ProductButton icon="" label="Girl" />
+                      </MenuItem>  
+                    </Grid>
+                    <Grid item xs={4}>  
+                      <MenuItem className={classes.productItem}>
+                        <ProductButton icon="" label="Child" />
+                      </MenuItem>
+                    </Grid>
+                    <Grid item xs={4}>  
+                      <MenuItem className={classes.productItem}>
+                        <ProductButton icon="" label="Baby" />
+                      </MenuItem>
+                    </Grid>
+                    <Grid item xs={4}>  
+                      <MenuItem className={classes.productItem}>
+                        <ProductButton icon="" label="Food" />
+                      </MenuItem>
+                    </Grid>
+                    <Grid item xs={4}>  
+                      <MenuItem className={classes.productItem}>
+                        <ProductButton icon="" label="Hygiene" />
+                      </MenuItem>
+                    </Grid>
+                  </Grid>    
+                </div>  
               </Menu>
             </div>  
             <Button color="inherit" className={classes.secondaryDropdown}>

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -121,7 +121,7 @@ class AppFrame extends React.Component {
 
   render() {
     const { children, classes, title } = this.props;
-    const { mobileOpen, anchorEl } = this.state;
+    const anchorEl = this.state.anchorEl;
     const open = Boolean(anchorEl);
     const divClass = this.mobileOpen ? classes.rootLocked : classes.root;
     return (

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -100,12 +100,7 @@ class AppFrame extends React.Component {
             <div className={classes.grow} />
 
             <div> 
-              <IconButton
-                aria-owns={open ? 'menu-appbar' : null}
-                aria-haspopup="true"
-                onClick={this.handleMenu}
-                color="inherit"
-              >
+              <IconButton color="inherit">
                 <SearchIcon />
               </IconButton>
             </div>  

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -13,6 +13,8 @@ import Menu from '@material-ui/core/Menu';
 import AppDrawer from "./AppDrawer";
 import { drawerTheme } from "../theme";
 
+const secondaryBarHeight = 30;
+
 const styles = theme => ({
   root: {
     display: "flex",
@@ -59,7 +61,7 @@ const styles = theme => ({
 
   },
   secondaryToolbar: {
-    height: 30,
+    height: secondaryBarHeight,
     minHeight: 0
   },
   secondaryDropdown: {
@@ -75,6 +77,7 @@ const styles = theme => ({
     flex: "1 1 100%",
     maxWidth: "100%",
     // margin: "0 auto",
+    marginTop: secondaryBarHeight,
     [theme.breakpoints.up("md")]: {
       maxWidth: theme.breakpoints.values.md
     }

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -4,6 +4,7 @@ import { withStyles, MuiThemeProvider } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
+import Button from '@material-ui/core/Button';
 import IconButton from "@material-ui/core/IconButton";
 import SearchIcon from '@material-ui/icons/Search';
 import MenuIcon from "@material-ui/icons/Menu";
@@ -36,8 +37,28 @@ const styles = theme => ({
       position: "absolute"
     },
     [theme.breakpoints.up("lg")]: {
-      width: "calc(100% - 250px)"
+      width: "calc(100% - 250px)",
+      height: 61
     }
+  },
+  secondaryBar: {
+    marginTop: 61,
+    height: 30,
+    transition: theme.transitions.create("width"),
+    "@media print": {
+      position: "absolute"
+    },
+    [theme.breakpoints.up("lg")]: {
+      width: "calc(100% - 250px)",
+    }
+  },
+  secondaryToolbar: {
+    height: 30,
+    minHeight: 0
+  },
+  secondaryDropdown: {
+    fontSize: 12,
+    color: "#b2e1f3"
   },
   drawer: {
     [theme.breakpoints.up("lg")]: {
@@ -107,6 +128,19 @@ class AppFrame extends React.Component {
 
           </Toolbar>
         </AppBar>
+
+        <AppBar className={classes.secondaryBar} position="fixed">
+          <Toolbar className={classes.secondaryToolbar}>
+            <Button color="inherit" className={classes.secondaryDropdown}>
+              Product
+            </Button>
+            <Button color="inherit" className={classes.secondaryDropdown}>
+              Status
+            </Button>
+          </Toolbar>
+        </AppBar>
+
+
         <MuiThemeProvider theme={drawerTheme}>
           <AppDrawer
             className={classes.drawer}

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -73,7 +73,11 @@ const styles = theme => ({
     color: "#b2e1f3"
   },
   secondaryMenu: {
-    width: 300
+    width: 300,
+    [theme.breakpoints.up('lg')]: {
+      top: 35,
+      left: 60
+    },
   },
   drawer: {
     [theme.breakpoints.up("lg")]: {

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -86,6 +86,10 @@ const styles = theme => ({
     [theme.breakpoints.up("lg")]: {
       display: "none"
     }
+  },
+  popupTitle: {
+    margin: "6 4",
+    fontSize: 15
   }
 });
 
@@ -177,7 +181,7 @@ class AppFrame extends React.Component {
                 }}
                 open={open}
               >
-                <p>Choose a category</p>
+                <div className={classes.popupTitle}>Choose a category</div>
                 <MenuItem onClick={this.handleClose}>Man</MenuItem>
                 <MenuItem onClick={this.handleClose}>Woman</MenuItem>
                 <MenuItem>Adult</MenuItem>

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -8,10 +8,9 @@ import Button from '@material-ui/core/Button';
 import IconButton from "@material-ui/core/IconButton";
 import SearchIcon from '@material-ui/icons/Search';
 import MenuIcon from "@material-ui/icons/Menu";
-import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import AppDrawer from "./AppDrawer";
-import ProductButton from "../components/ProductButton";
+import ProductCategoryGridItem from "./ProductCategoryGridItem";
 import Grid from '@material-ui/core/Grid';
 import { drawerTheme } from "../theme";
 
@@ -197,51 +196,15 @@ class AppFrame extends React.Component {
                 <div className={classes.popupTitle}>Choose a category</div>
                 <div className={classes.productRoot}>
                   <Grid container>
-                    <Grid item xs={4}>
-                      <MenuItem className={classes.productItem}>
-                        <ProductButton icon="" label="Man" />
-                      </MenuItem>
-                    </Grid>
-                    <Grid item xs={4}>
-                      <MenuItem className={classes.productItem}>
-                        <ProductButton icon="" label="Woman" />
-                      </MenuItem>  
-                    </Grid>
-                    <Grid item xs={4}>
-                      <MenuItem className={classes.productItem}>
-                        <ProductButton icon="" label="Adult" />
-                      </MenuItem>  
-                    </Grid>
-                    <Grid item xs={4}>  
-                      <MenuItem className={classes.productItem}>
-                        <ProductButton icon="" label="Boy" />
-                      </MenuItem>  
-                    </Grid>
-                    <Grid item xs={4}>  
-                      <MenuItem className={classes.productItem}>
-                        <ProductButton icon="" label="Girl" />
-                      </MenuItem>  
-                    </Grid>
-                    <Grid item xs={4}>  
-                      <MenuItem className={classes.productItem}>
-                        <ProductButton icon="" label="Child" />
-                      </MenuItem>
-                    </Grid>
-                    <Grid item xs={4}>  
-                      <MenuItem className={classes.productItem}>
-                        <ProductButton icon="" label="Baby" />
-                      </MenuItem>
-                    </Grid>
-                    <Grid item xs={4}>  
-                      <MenuItem className={classes.productItem}>
-                        <ProductButton icon="" label="Food" />
-                      </MenuItem>
-                    </Grid>
-                    <Grid item xs={4}>  
-                      <MenuItem className={classes.productItem}>
-                        <ProductButton icon="" label="Hygiene" />
-                      </MenuItem>
-                    </Grid>
+                    <ProductCategoryGridItem icon="" label="Man" />
+                    <ProductCategoryGridItem icon="" label="Woman" />
+                    <ProductCategoryGridItem icon="" label="Adult" />
+                    <ProductCategoryGridItem icon="" label="Boy" />
+                    <ProductCategoryGridItem icon="" label="Girl" />
+                    <ProductCategoryGridItem icon="" label="Child" />
+                    <ProductCategoryGridItem icon="" label="Baby" />
+                    <ProductCategoryGridItem icon="" label="Food" />
+                    <ProductCategoryGridItem icon="" label="Hygiene" />
                   </Grid>    
                 </div>  
               </Menu>

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -47,7 +47,7 @@ const styles = theme => ({
   },
   secondaryBar: {
     marginTop: 61,
-    height: 30,
+    height: secondaryBarHeight,
     transition: theme.transitions.create("width"),
     "@media print": {
       position: "absolute"

--- a/src/components/AppFrame.js
+++ b/src/components/AppFrame.js
@@ -8,6 +8,8 @@ import Button from '@material-ui/core/Button';
 import IconButton from "@material-ui/core/IconButton";
 import SearchIcon from '@material-ui/icons/Search';
 import MenuIcon from "@material-ui/icons/Menu";
+import MenuItem from '@material-ui/core/MenuItem';
+import Menu from '@material-ui/core/Menu';
 import AppDrawer from "./AppDrawer";
 import { drawerTheme } from "../theme";
 
@@ -82,7 +84,8 @@ const styles = theme => ({
 
 class AppFrame extends React.Component {
   state = {
-    mobileOpen: false
+    mobileOpen: false,
+    anchorEl: null
   };
 
   handleDrawerOpen = () => {
@@ -93,8 +96,22 @@ class AppFrame extends React.Component {
     this.setState({ mobileOpen: false });
   };
 
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  handleMenu = event => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
   render() {
     const { children, classes, title } = this.props;
+    const { mobileOpen, anchorEl } = this.state;
+    const open = Boolean(anchorEl);
     const divClass = this.mobileOpen ? classes.rootLocked : classes.root;
     return (
       <div className={divClass}>
@@ -129,11 +146,37 @@ class AppFrame extends React.Component {
           </Toolbar>
         </AppBar>
 
+
         <AppBar className={classes.secondaryBar} position="fixed">
           <Toolbar className={classes.secondaryToolbar}>
-            <Button color="inherit" className={classes.secondaryDropdown}>
-              Product
-            </Button>
+            <div>
+              <Button 
+                color="inherit"
+                onClick={this.handleMenu} 
+                className={classes.secondaryDropdown}
+              >
+                Product
+              </Button>
+              <Menu
+                id="menu-appbar"
+                anchorEl={anchorEl}
+                anchorOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+                open={open}
+              >
+                <p>Choose a category</p>
+                <MenuItem onClick={this.handleClose}>Man</MenuItem>
+                <MenuItem onClick={this.handleClose}>Woman</MenuItem>
+                <MenuItem>Adult</MenuItem>
+                <MenuItem>...</MenuItem>
+              </Menu>
+            </div>  
             <Button color="inherit" className={classes.secondaryDropdown}>
               Status
             </Button>

--- a/src/components/ProductCategoryGridItem.js
+++ b/src/components/ProductCategoryGridItem.js
@@ -1,0 +1,23 @@
+import React from "react";
+import Grid from '@material-ui/core/Grid';
+import MenuItem from '@material-ui/core/MenuItem';
+import ProductButton from "../components/ProductButton";
+import { withStyles } from "@material-ui/core/styles";
+
+const styles = theme => ({
+  productItem: {
+    margin: "3px"
+  }
+});
+
+const ProductCategoryGridItem = ({ classes, icon, label }) => {
+  return (
+    <Grid item xs={4}>  
+      <MenuItem className={classes.productItem}>
+        <ProductButton icon={icon} label={label} />
+      </MenuItem>
+    </Grid>
+  );
+};
+
+export default withStyles(styles)(ProductCategoryGridItem);

--- a/t
+++ b/t
@@ -1,0 +1,76 @@
+[1m────────────────────────────────────────────────────────────────────────────────────────────────
+[1mmodified: src/components/AppFrame.js
+[1m────────────────────────────────────────────────────────────────────────────────────────────────
+[36m@ AppFrame.js:11 @[1m[38;5;146m import Button from '@material-ui/core/Button';[0m
+import IconButton from "@material-ui/core/IconButton";[m
+import SearchIcon from '@material-ui/icons/Search';[m
+import MenuIcon from "@material-ui/icons/Menu";[m
+[31mimport MenuItem from '@material-ui/core/MenuItem';[m
+import Menu from '@material-ui/core/Menu';[m
+import AppDrawer from "./AppDrawer";[m
+[31mimport Product[7mButton from "../components/ProductButton[27m";[m
+[32m[m[32mimport Product[7mCategoryGridItem from "./ProductCategoryGridItem[27m";[m
+import Grid from '@material-ui/core/Grid';[m
+import { drawerTheme } from "../theme";[m
+[m
+[36m@ AppFrame.js:199 @[1m[38;5;146m class AppFrame extends React.Component {[0m
+                <div className={classes.popupTitle}>Choose a category</div>[m
+                <div className={classes.productRoot}>[m
+                  <Grid container>[m
+[31m                    <Grid item xs={4}>[m
+[31m                      <MenuItem className={classes.productItem}>[m
+[31m                        <ProductButton icon="" label="Man" />[m
+[31m                      </MenuItem>[m
+[31m                    </Grid>[m
+[31m                    <Grid item xs={4}>[m
+[31m                      <MenuItem className={classes.productItem}>[m
+[31m                        <ProductButton icon="" label="Woman" />[m
+[31m                      </MenuItem>  [m
+[31m                    </Grid>[m
+[31m                    <Grid item xs={4}>[m
+[31m                      <MenuItem className={classes.productItem}>[m
+[31m                        <ProductButton icon="" label="Adult" />[m
+[31m                      </MenuItem>  [m
+[31m                    </Grid>[m
+[31m                    <Grid item xs={4}>  [m
+[31m                      <MenuItem className={classes.productItem}>[m
+[31m                        <ProductButton icon="" label="Boy" />[m
+[31m                      </MenuItem>  [m
+[31m                    </Grid>[m
+[31m                    <Grid item xs={4}>  [m
+[31m                      <MenuItem className={classes.productItem}>[m
+[31m                        <ProductButton icon="" label="Girl" />[m
+[31m                      </MenuItem>  [m
+[31m                    </Grid>[m
+[31m                    <Grid item xs={4}>  [m
+[31m                      <MenuItem className={classes.productItem}>[m
+[31m                        <ProductButton icon="" label="Child" />[m
+[31m                      </MenuItem>[m
+[31m                    </Grid>[m
+[31m                    <Grid item xs={4}>  [m
+[31m                      <MenuItem className={classes.productItem}>[m
+[31m                        <ProductButton icon="" label="Baby" />[m
+[31m                      </MenuItem>[m
+[31m                    </Grid>[m
+[31m                    <Grid item xs={4}>  [m
+[31m                      <MenuItem className={classes.productItem}>[m
+[31m                        <ProductButton icon="" label="Food" />[m
+[31m                      </MenuItem>[m
+[31m                    </Grid>[m
+[31m                    <Grid item xs={4}>  [m
+[31m                      <MenuItem className={classes.productItem}>[m
+[31m                        <ProductButton icon="" label="Hygiene" />[m
+[31m                      </MenuItem>[m
+[31m                    </Grid>[m
+[32m[m[32m                    <ProductCategoryGridItem icon="" label="Man" />[m
+[32m[m[32m                    <ProductCategoryGridItem icon="" label="Woman" />[m
+[32m[m[32m                    <ProductCategoryGridItem icon="" label="Adult" />[m
+[32m[m[32m                    <ProductCategoryGridItem icon="" label="Boy" />[m
+[32m[m[32m                    <ProductCategoryGridItem icon="" label="Girl" />[m
+[32m[m[32m                    <ProductCategoryGridItem icon="" label="Child" />[m
+[32m[m[32m                    <ProductCategoryGridItem icon="" label="Baby" />[m
+[32m[m[32m                    <ProductCategoryGridItem icon="" label="Food" />[m
+[32m[m[32m                    <ProductCategoryGridItem icon="" label="Hygiene" />[m
+                  </Grid>    [m
+                </div>  [m
+              </Menu>[m


### PR DESCRIPTION
As part of the redesign of the Boxwise application, this PR focuses on the drawer and the navigation bar (app bar).

Here's a screenshot of the current result:
![screenshot from 2018-07-27 14-23-22](https://user-images.githubusercontent.com/1527188/43352546-124bc66c-91f3-11e8-99ee-b0cf27b4d8a4.png)

A few comments about these changes:
- A second `AppBar` was used in AppFrame.js in order to create the secondary menu (the one with Product and Status drowdowns). I'm not familiar with Material UI (nor with React actually. And I'm not a front-end developer - I just sometimes do front-end development) so there may be a better way to approch this problem. Although this library didn't put any restriction in having 2 `AppBar`, it felt a bit hacky when it came to position the secondary bar and the page content (`Page` component).
- When redesigning the drawer, I didn't know where the links were leading to. Targets will have to be implemented.
- I implemented a dropdown for the `Product` menu, as per recommended by the Material UI docs for `AppBar`. Only dummy content for now (real content should be part of another PR to keep this one small and tidy enough). Edit Aug 5 2018: I added placeholders to that popup menu.
- I just noticed I forgot to include the down arrow next to the drop down menus! I'll have to take care of this.

As you can see, this PR is to be merged to Boxwise's `master`. Should I target another branch, as some features are not production-ready (eg. dropdowns...)? Please let me know how you'd like me to proceed. And feel free to comment 

Thanks,
Etienne