### PR TITLE
Add explicit reference to master branch in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
 # we should at least stop people from doing it accidentally.
 - cp .travis/.env.production ./
 - yarn build
+branches:
+  only:
+  - master
 deploy:
   provider: firebase
   project: boxwise-production


### PR DESCRIPTION
This should allow us to turn off non-named branch builds in Travis and therefore only have one CI job per pull request