### PR TITLE
Fix to remove firebase deprecation warning

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -16,6 +16,6 @@ if (!firebase.apps.length) {
 }
 
 export const firestore = firebase.firestore();
-firestore.settings({ timestampsInSnapshots: true });
+firestore.settings({});
 
 export default firebase;

--- a/utils/generate-test-data.js
+++ b/utils/generate-test-data.js
@@ -77,7 +77,7 @@ const initFirebase = () => {
     }
 
     firestore = firebase.firestore();
-    firestore.settings({ timestampsInSnapshots: true });
+    firestore.settings({ });
 };
 
 const setupAuth = () => {


### PR DESCRIPTION
timestampsInSnapshots always defaults to true and will be soon removed.