### PR TITLE
Bump Node version 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ before_install:
 - if [[ -n "$encrypted_5b7b89e871be_key" ]]; then openssl aes-256-cbc -K $encrypted_5b7b89e871be_key
   -iv $encrypted_5b7b89e871be_iv -in .travis/.service-account-key.json.enc -out .service-account-key.json
   -d; fi
+# install specific version of yarn
+- curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
+- export PATH="$HOME/.yarn/bin:$PATH"
 script:
 - yarn test
 # .env.production is kept out of the root directory, because if it were there

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '8'
+- 'node' # latest stable build
 cache: yarn
 before_install:
 - if [[ -n "$encrypted_5b7b89e871be_key" ]]; then openssl aes-256-cbc -K $encrypted_5b7b89e871be_key


### PR DESCRIPTION
Hopefully this gives us a new travis CI image and therefore a newer version of yarn. Current builds on travis are running on v1.3.2.