### PR TITLE
Fix up the firebase factory 

### DIFF
--- a/src/firebaseFactory.js
+++ b/src/firebaseFactory.js
@@ -11,13 +11,8 @@ const config = {
   messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID
 };
 
-export default function initialize() {
-  firebase.initializeApp(config);
+const app = firebase.initializeApp(config);
+const db = firebase.firestore(app);
+db.enablePersistence();
 
-  firebase
-    .firestore()
-    .settings({})
-    .enablePersistence();
-
-  return firebase;
-}
+export { db, firebase };

--- a/src/index.js
+++ b/src/index.js
@@ -9,15 +9,13 @@ import App from "./App";
 import config from "./config";
 import * as serviceWorker from "./serviceWorker";
 import store from "./store";
-import firebaseConfig from "./firebaseConfig";
+import { firebase } from "./firebaseFactory";
 
 if (config.SENTRY_URI) {
   Sentry.init({
     dsn: config.SENTRY_URI
   });
 }
-
-const firebase = firebaseConfig.initializeApp();
 
 ReactDOM.render(
   <FirestoreProvider firebase={firebase}>

--- a/src/modules/auth/actions.js
+++ b/src/modules/auth/actions.js
@@ -1,5 +1,4 @@
-import firebase from "firebase/app";
-
+import { firebase } from "firebaseFactory";
 import { fetchProfile } from "modules/profile/actions";
 import { captureException } from "errorHandling";
 import { asyncAction, editAction } from "commons/utils/action-creators";

--- a/src/modules/boxes/actions.js
+++ b/src/modules/boxes/actions.js
@@ -1,13 +1,10 @@
-import firebase from "firebase/app";
-
+import { firebase, db } from "firebaseFactory";
 import { captureException } from "errorHandling";
 
 const BOX_ADD_ = TYPE => `BOX_ADD_${TYPE}`;
 export const BOX_ADD_START = BOX_ADD_`START`;
 export const BOX_ADD_SUCCESS = BOX_ADD_`SUCCESS`;
 export const BOX_ADD_ERROR = BOX_ADD_`ERROR`;
-
-const db = firebase.firestore();
 
 export const addBox = ({
   product,

--- a/src/modules/boxes/containers/BoxListContainer.js
+++ b/src/modules/boxes/containers/BoxListContainer.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { connect } from "react-redux";
 import { FirestoreCollection } from "react-firestore";
-import firebase from "firebase/app";
 
+import { db } from "firebaseFactory";
 import { ProductsCollection } from "modules/products/components";
 
 import BoxList from "../components/BoxList";
@@ -21,14 +21,12 @@ class BoxListContainer extends React.Component {
     }
     const { organization } = profile.data;
 
-    const filters = [
-      ["organization", "==", firebase.firestore().doc(organization.ref)]
-    ];
+    const filters = [["organization", "==", db.doc(organization.ref)]];
     if (selectedProductFilter) {
       filters.push([
         "product",
         "==",
-        firebase.firestore().doc(`products/${selectedProductFilter}`)
+        db.doc(`products/${selectedProductFilter}`)
       ]);
     }
 

--- a/src/modules/products/actions.js
+++ b/src/modules/products/actions.js
@@ -1,5 +1,4 @@
-import firebase from "firebase/app";
-
+import { firebase, db } from "firebaseFactory";
 import {
   addAction,
   listAction,
@@ -12,8 +11,6 @@ export const PRODUCT_LIST = listAction("product");
 export const PRODUCT_ADD = addAction("product");
 export const PRODUCT_EDIT = editAction("product");
 export const PRODUCT_DELETE = deleteAction("product");
-
-const db = firebase.firestore();
 
 // ***** Plain Actions ***** //
 

--- a/src/modules/products/components/ProductsCollection.js
+++ b/src/modules/products/components/ProductsCollection.js
@@ -1,12 +1,13 @@
 import React from "react";
 import { FirestoreCollection } from "react-firestore";
-import firebase from "firebase/app";
+
+import { db } from "firebaseFactory";
 
 const ProductsCollection = ({ organizationRef, ...props }) => (
   <FirestoreCollection
     path="products"
     filter={[
-      ["organization", "==", firebase.firestore().doc(organizationRef)],
+      ["organization", "==", db.doc(organizationRef)],
       ["isDeleted", "==", false]
     ]}
     sort="category:asc,name:asc"

--- a/src/modules/profile/actions.js
+++ b/src/modules/profile/actions.js
@@ -1,9 +1,7 @@
-import firebase from "firebase/app";
-
+import { db } from "firebaseFactory";
 import { captureException } from "errorHandling";
 
 const FETCH_PROFILE_ = TYPE => `FETCH_PROFILE_${TYPE}`;
-const db = firebase.firestore();
 
 export const FETCH_PROFILE_START = FETCH_PROFILE_`START`;
 export const FETCH_PROFILE_SUCCESS = FETCH_PROFILE_`SUCCESS`;

--- a/src/modules/signup/actions.js
+++ b/src/modules/signup/actions.js
@@ -1,5 +1,4 @@
-import firebase from "firebase/app";
-const db = firebase.firestore();
+import { firebase, db } from "firebaseFactory";
 
 const setProfile = ({ uid }, data) => {
   return db

--- a/src/modules/signup/actions.test.js
+++ b/src/modules/signup/actions.test.js
@@ -1,11 +1,10 @@
-import firebase from "firebase/app";
+import { db } from "firebaseFactory";
 
 import { getOrAddInvite } from "./actions";
 
 // firebase mock doesn't support querying by reference
 test.skip("getOrAddInvite", () => {
-  return firebase
-    .firestore()
+  return db
     .collection("organizations")
     .add({ name: "Boxaid" })
     .then(org => {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,20 +3,20 @@
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import "jest-enzyme";
+import firebaseMock from "firebase-mock";
 
 Enzyme.configure({ adapter: new Adapter() });
 
-jest.mock("firebase/app", () => {
-  const firebasemock = require("firebase-mock");
-  const mockauth = new firebasemock.MockAuthentication();
-  const mockfirestore = new firebasemock.MockFirestore();
-  const mocksdk = new firebasemock.MockFirebaseSdk(
+jest.doMock("firebaseFactory", () => {
+  const mockAuth = new firebaseMock.MockAuthentication();
+  const mockFirestore = new firebaseMock.MockFirestore();
+  const mockSdk = new firebaseMock.MockFirebaseSdk(
     null, // RTDB
-    () => mockauth,
-    () => mockfirestore
+    () => mockAuth,
+    () => mockFirestore
   );
-  const firebase = mocksdk.initializeApp();
+  const firebase = mockSdk.initializeApp();
   firebase.auth().autoFlush(true);
   firebase.firestore().autoFlush(true);
-  return firebase;
+  return { db: firebase.firestore(), firebase };
 });


### PR DESCRIPTION
I broke this in https://github.com/boxwise/boxwise/commit/c91b894c78ca0ee3be92fff6897ea58a0d81f575 .  We need to pass around the specific configured instance - and firestore has to be explicitly included for the function to be available. This didn't fail any tests :/ I'm not addressing that here though, as we don't yet have a nice way to run integration tests across the app.