### PR TITLE
Fixing integration firestore tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "scripts": {
     "start": "NODE_PATH=src react-scripts start",
     "build": "NODE_PATH=src react-scripts build",
-    "test": "NODE_PATH=src react-scripts test --modulePaths=src",
-    "test-with-coverage": "NODE_PATH=src react-scripts test --modulePaths=src --coverage",
+    "test": "react-scripts test --modulePaths=src",
+    "test-with-coverage": "react-scripts test --modulePaths=src --coverage",
     "test-no-cycles": "madge \"src/index.jsx\" --circular",
     "upload-coverage-report": "./node_modules/.bin/codecov",
     "eject": "react-scripts eject",

--- a/src/firestore.rules.test.js
+++ b/src/firestore.rules.test.js
@@ -1,20 +1,15 @@
 import "babel-polyfill";
 import path from "path";
-import fs from "fs";
 
 import * as firestore from "expect-firestore";
 
-const serviceAccountKey = fs.existsSync(".service-account-key.json")
-  ? // eslint-disable-next-line import/no-unresolved
-    require(".service-account-key.json")
-  : null;
-
-const describeButSkipIfNoKey = serviceAccountKey ? describe : describe.skip;
-if (!serviceAccountKey) {
-  // eslint-disable-next-line no-console
-  console.warn(
-    "Skipping firestore rule tests. Provide .service-account-key.json to run these."
-  );
+let describeButSkipIfNoKey = describe;
+let serviceAccountKey;
+try {
+  // eslint-disable-next-line global-require
+  serviceAccountKey = require("../.service-account-key.json");
+} catch (e) {
+  describeButSkipIfNoKey = describe.skip;
 }
 
 const TEST_DATA = {
@@ -54,7 +49,7 @@ describeButSkipIfNoKey("firestore.rules", () => {
       credential: serviceAccountKey
     });
     await database.authorize();
-    database.setRulesFromFile(path.join(__dirname, "../../firestore.rules"));
+    database.setRulesFromFile(path.join(__dirname, "../firestore.rules"));
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Reverting change in https://github.com/boxwise/boxwise/commit/f7b7dddfc64ebfa3257be2d6f82839f99ebdadea as file detection didn't work. Fixing the import path instead.

Also, remove usage of NODE_PATH for testing as we're specifying via modulePaths anyway.