### PR TITLE
Simplify action handlers error handling

### DIFF
--- a/src/errorHandling.js
+++ b/src/errorHandling.js
@@ -3,9 +3,33 @@ import * as Sentry from "@sentry/browser";
 // eslint-disable-next-line import/prefer-default-export
 export function captureException(error, errorInfo) {
   // eslint-disable-next-line no-console
-  console.error(error);
+  console.error(error, errorInfo);
   Sentry.captureException(error, { extra: errorInfo });
 }
+
+// copied from https://github.com/captbaritone/raven-for-redux/issues/93#issuecomment-435854873
+export const sentryMiddleware = store => {
+  Sentry.addGlobalEventProcessor(event => {
+    const state = store.getState();
+
+    return {
+      ...event,
+      extra: {
+        ...event.extra,
+        "redux:state": state
+      }
+    };
+  });
+
+  return next => action => {
+    Sentry.addBreadcrumb({
+      category: "redux-action",
+      message: action.type
+    });
+
+    return next(action);
+  };
+};
 
 export const logErrorActionsAsExceptions = () => next => action => {
   if (action.type.endsWith("_ERROR")) {

--- a/src/errorHandling.js
+++ b/src/errorHandling.js
@@ -6,3 +6,10 @@ export function captureException(error, errorInfo) {
   console.error(error);
   Sentry.captureException(error, { extra: errorInfo });
 }
+
+export const logErrorActionsAsExceptions = () => next => action => {
+  if (action.type.endsWith("_ERROR")) {
+    Sentry.captureException(action.payload);
+  }
+  return next(action);
+};

--- a/src/modules/auth/actions.js
+++ b/src/modules/auth/actions.js
@@ -56,14 +56,9 @@ export const userPasswordChange = ({
   return firebase
     .auth()
     .signInWithEmailAndPassword(email, currentPassword)
+    .then(({ user }) => user.updatePassword(newPassword))
     .then(
-      ({ user }) =>
-        user
-          .updatePassword(newPassword)
-          .then(
-            () => dispatch({ type: PASSWORD_EDIT.SUCCESS }),
-            error => dispatch({ type: PASSWORD_EDIT.ERROR, payload: error })
-          ),
+      () => dispatch({ type: PASSWORD_EDIT.SUCCESS }),
       error => dispatch({ type: PASSWORD_EDIT.ERROR, payload: error })
     );
 };

--- a/src/modules/auth/actions.js
+++ b/src/modules/auth/actions.js
@@ -1,6 +1,5 @@
 import { firebase } from "firebaseFactory";
 import { fetchProfile } from "modules/profile/actions";
-import { captureException } from "errorHandling";
 import { asyncAction, editAction } from "commons/utils/action-creators";
 
 export const USER_SIGN_IN = asyncAction("USER_SIGN_IN");
@@ -31,11 +30,10 @@ export const userSignIn = ({ email, password }) => dispatch => {
   firebase
     .auth()
     .signInWithEmailAndPassword(email, password)
-    .then(({ user }) => dispatch(userSignInSuccess(user)))
-    .catch(error => {
-      captureException(error);
-      dispatch({ type: USER_SIGN_IN.ERROR, payload: error });
-    });
+    .then(
+      ({ user }) => dispatch(userSignInSuccess(user)),
+      error => dispatch({ type: USER_SIGN_IN.ERROR, payload: error })
+    );
 };
 
 export const resetPassword = ({ email }) => dispatch => {
@@ -43,11 +41,10 @@ export const resetPassword = ({ email }) => dispatch => {
   firebase
     .auth()
     .sendPasswordResetEmail(email)
-    .then(() => dispatch({ type: PASSWORD_RESET.SUCCESS }))
-    .catch(error => {
-      captureException(error);
-      dispatch({ type: PASSWORD_RESET.ERROR, payload: error });
-    });
+    .then(
+      () => dispatch({ type: PASSWORD_RESET.SUCCESS }),
+      error => dispatch({ type: PASSWORD_RESET.ERROR, payload: error })
+    );
 };
 
 export const userPasswordChange = ({
@@ -59,21 +56,16 @@ export const userPasswordChange = ({
   return firebase
     .auth()
     .signInWithEmailAndPassword(email, currentPassword)
-    .then(({ user }) =>
-      user
-        .updatePassword(newPassword)
-        .then(() => dispatch({ type: PASSWORD_EDIT.SUCCESS }))
-        .catch(error => {
-          captureException(error);
-          dispatch({ type: PASSWORD_EDIT.ERROR, payload: error });
-          throw error;
-        })
-    )
-    .catch(error => {
-      captureException(error);
-      dispatch({ type: PASSWORD_EDIT.ERROR, payload: error });
-      throw error;
-    });
+    .then(
+      ({ user }) =>
+        user
+          .updatePassword(newPassword)
+          .then(
+            () => dispatch({ type: PASSWORD_EDIT.SUCCESS }),
+            error => dispatch({ type: PASSWORD_EDIT.ERROR, payload: error })
+          ),
+      error => dispatch({ type: PASSWORD_EDIT.ERROR, payload: error })
+    );
 };
 
 export const registerAuthStateObserver = () => (dispatch, getState) => {

--- a/src/modules/boxes/actions.js
+++ b/src/modules/boxes/actions.js
@@ -1,5 +1,4 @@
 import { firebase, db } from "firebaseFactory";
-import { captureException } from "errorHandling";
 
 // eslint-disable-next-line no-underscore-dangle
 const BOX_ADD_ = TYPE => `BOX_ADD_${TYPE}`;
@@ -30,13 +29,14 @@ export const addBox = ({
     .add(box)
     .then(ref => ref.get())
     .then(box => box.data())
-    .then(box => {
-      dispatch({ type: BOX_ADD_SUCCESS, payload: box });
-      return { error: false, data: box };
-    })
-    .catch(error => {
-      captureException(error);
-      dispatch({ type: BOX_ADD_ERROR, payload: error });
-      return { error };
-    });
+    .then(
+      box => {
+        dispatch({ type: BOX_ADD_SUCCESS, payload: box });
+        return { error: false, data: box };
+      },
+      error => {
+        dispatch({ type: BOX_ADD_ERROR, payload: error });
+        return { error };
+      }
+    );
 };

--- a/src/modules/products/actions.js
+++ b/src/modules/products/actions.js
@@ -5,7 +5,6 @@ import {
   editAction,
   deleteAction
 } from "commons/utils/action-creators";
-import { captureException } from "errorHandling";
 
 export const PRODUCT_LIST = listAction("product");
 export const PRODUCT_ADD = addAction("product");
@@ -41,11 +40,10 @@ export const productList = () => (dispatch, getState) => {
     .orderBy("name", "asc")
     .get()
     .then(({ docs }) => docs.map(getProductFromData))
-    .then(payload => dispatch({ type: PRODUCT_LIST.SUCCESS, payload }))
-    .catch(err => {
-      captureException(err);
-      dispatch({ type: PRODUCT_LIST.ERROR, payload: err });
-    });
+    .then(
+      payload => dispatch({ type: PRODUCT_LIST.SUCCESS, payload }),
+      err => dispatch({ type: PRODUCT_LIST.ERROR, payload: err })
+    );
 };
 
 export const productAdd = product => (dispatch, getState) => {
@@ -64,13 +62,14 @@ export const productAdd = product => (dispatch, getState) => {
     .collection("products")
     .add(values)
     .then(ref => ref.get())
-    .then(res =>
-      dispatch({ type: PRODUCT_ADD.SUCCESS, payload: getProductFromData(res) })
-    )
-    .catch(err => {
-      captureException(err); // TODO: actually handle the error
-      dispatch({ type: PRODUCT_ADD.ERROR, payload: err });
-    });
+    .then(
+      res =>
+        dispatch({
+          type: PRODUCT_ADD.SUCCESS,
+          payload: getProductFromData(res)
+        }),
+      err => dispatch({ type: PRODUCT_ADD.ERROR, payload: err })
+    );
 };
 
 export const productEdit = product => dispatch => {
@@ -80,13 +79,14 @@ export const productEdit = product => dispatch => {
   return ref
     .update(product)
     .then(() => ref.get())
-    .then(res =>
-      dispatch({ type: PRODUCT_EDIT.SUCCESS, payload: getProductFromData(res) })
-    )
-    .catch(err => {
-      captureException(err); // TODO: actually handle the error
-      dispatch({ type: PRODUCT_EDIT.ERROR, payload: err });
-    });
+    .then(
+      res =>
+        dispatch({
+          type: PRODUCT_EDIT.SUCCESS,
+          payload: getProductFromData(res)
+        }),
+      err => dispatch({ type: PRODUCT_EDIT.ERROR, payload: err })
+    );
 };
 
 export const productDelete = productId => dispatch => {
@@ -96,9 +96,8 @@ export const productDelete = productId => dispatch => {
     .collection("products")
     .doc(productId)
     .update({ isDeleted: true })
-    .then(() => dispatch({ type: PRODUCT_DELETE.SUCCESS, payload: productId }))
-    .catch(err => {
-      captureException(err);
-      dispatch({ type: PRODUCT_DELETE.ERROR });
-    });
+    .then(
+      () => dispatch({ type: PRODUCT_DELETE.SUCCESS, payload: productId }),
+      err => dispatch({ type: PRODUCT_DELETE.ERROR, paylod: err })
+    );
 };

--- a/src/modules/profile/actions.js
+++ b/src/modules/profile/actions.js
@@ -1,5 +1,4 @@
 import { db } from "firebaseFactory";
-import { captureException } from "errorHandling";
 
 // eslint-disable-next-line no-underscore-dangle
 const FETCH_PROFILE_ = TYPE => `FETCH_PROFILE_${TYPE}`;
@@ -29,8 +28,5 @@ export const fetchProfile = userUID => dispatch => {
         dispatch({ type: FETCH_PROFILE_SUCCESS, payload: profile });
       });
     })
-    .catch(err => {
-      captureException(err);
-      dispatch({ type: FETCH_PROFILE_ERROR, payload: err });
-    });
+    .catch(err => dispatch({ type: FETCH_PROFILE_ERROR, payload: err }));
 };

--- a/src/store.js
+++ b/src/store.js
@@ -5,7 +5,7 @@ import user from "modules/auth/reducer";
 import products from "modules/products/reducer";
 import boxes from "modules/boxes/reducer";
 import profile from "modules/profile/reducer";
-import { logErrorActionsAsExceptions } from "errorHandling";
+import { logErrorActionsAsExceptions, sentryMiddleware } from "errorHandling";
 
 const rootReducer = combineReducers({
   products,
@@ -19,7 +19,9 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const store = createStore(
   rootReducer,
-  composeEnhancers(applyMiddleware(thunk, logErrorActionsAsExceptions))
+  composeEnhancers(
+    applyMiddleware(thunk, sentryMiddleware, logErrorActionsAsExceptions)
+  )
 );
 
 export default store;

--- a/src/store.js
+++ b/src/store.js
@@ -5,6 +5,7 @@ import user from "modules/auth/reducer";
 import products from "modules/products/reducer";
 import boxes from "modules/boxes/reducer";
 import profile from "modules/profile/reducer";
+import { logErrorActionsAsExceptions } from "errorHandling";
 
 const rootReducer = combineReducers({
   products,
@@ -18,7 +19,7 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const store = createStore(
   rootReducer,
-  composeEnhancers(applyMiddleware(thunk))
+  composeEnhancers(applyMiddleware(thunk, logErrorActionsAsExceptions))
 );
 
 export default store;


### PR DESCRIPTION
Hook up middleware to pick up our 'error' actions and throw them - which means they'll then be captured by Sentry and logged. This removes the need to call out to sentry within our actions directly.