### PR TITLE
Remove cypress recording key from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
 - yarn lint
 - cp .travis/.env.feature-tests ./.env.local
 - yarn start &
-- cypress run --record --key f76b77d4-b71f-4b5d-8f07-564c76dda5e7
+- cypress run --record
 # .env.production is kept out of the root directory, because if it were there
 # running "firebase deploy" would create a clone of our real production
 # environment. This is not something we can stop (they are public details) but


### PR DESCRIPTION
**delete**: cypress recording key from travis.yml

I've generated fresh new key in Cypress and it's saved as TravisCI environment variable now (this should/could have been a part of #451)