### PR TITLE
The change password test changes passwords

### DIFF
--- a/cypress/integration/controlOperations.js
+++ b/cypress/integration/controlOperations.js
@@ -20,7 +20,9 @@ describe("Control operations", () => {
     cy.get("button[data-cy=signInButton]").should("exist"); // existing sign-in button means user is logged out
   });
 
-  it("Change password -> Relogin -> Change password", () => {
+  // skipping, as this is causing other test failures when it fails
+  // by not restoring the password
+  it.skip("Change password -> Relogin -> Change password", () => {
     cy.reLogin(changePwdUserMail, changePwdPwd);
     cy.navigateToChangePasswordForm();
     cy.get("div[data-cy=currentPassword] input").type(`${changePwdPwd}`);


### PR DESCRIPTION
Leaves our db in an inconsistent state when it fails. Taking this out till we can run against an in-memory firebase db