### PR TITLE
Cypress test issues - signIn button click, changePassword test faulty DB state, appDrawer button not always visible

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -4,9 +4,7 @@
     "testUser": "browsertestuser",
     "testUserMail": "browsertestuser@example.com",
     "testPwd": "browsertestuser",
-    "changePwdUserMail": "changePwdUser@example.com",
-    "changePwdPwd": "changePwdPwd",
-    "newPwd": "newPwd"
+    "newPwd": "browsertestuser"
   },
   "projectId": "e6jvz9"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -3,7 +3,7 @@
     "testOrg": "browserTestOrganization",
     "testUser": "browsertestuser",
     "testUserMail": "browsertestuser@example.com",
-    "testPwd": "browserTestPassword"
+    "testPwd": "browsertestuser"
   },
   "projectId": "e6jvz9"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -3,7 +3,7 @@
     "testOrg": "browserTestOrganization",
     "testUser": "browsertestuser",
     "testUserMail": "browsertestuser@example.com",
-    "testPwd": "browserTestPassword",
+    "testPwd": "browserTestPassword"
   },
   "projectId": "e6jvz9"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -3,8 +3,7 @@
     "testOrg": "browserTestOrganization",
     "testUser": "browsertestuser",
     "testUserMail": "browsertestuser@example.com",
-    "testPwd": "browsertestuser",
-    "newPwd": "browsertestuser"
+    "testPwd": "browserTestPassword",
   },
   "projectId": "e6jvz9"
 }

--- a/cypress/config.js
+++ b/cypress/config.js
@@ -1,13 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+
 export const getTestConfig = () => {
   const testUser = Cypress.env("testUser");
   const testUserMail = Cypress.env("testUserMail");
   const testPwd = Cypress.env("testPwd");
-  return { testUser, testUserMail, testPwd };
-};
-
-export const getChangePwdConfig = () => {
-  const changePwdUserMail = Cypress.env("changePwdUserMail");
-  const changePwdPwd = Cypress.env("changePwdPwd");
   const newPwd = Cypress.env("newPwd");
-  return { changePwdUserMail, changePwdPwd, newPwd };
+  return { testUser, testUserMail, testPwd, newPwd };
 };

--- a/cypress/config.js
+++ b/cypress/config.js
@@ -4,6 +4,5 @@ export const getTestConfig = () => {
   const testUser = Cypress.env("testUser");
   const testUserMail = Cypress.env("testUserMail");
   const testPwd = Cypress.env("testPwd");
-  const newPwd = Cypress.env("newPwd");
-  return { testUser, testUserMail, testPwd, newPwd };
+  return { testUser, testUserMail, testPwd };
 };

--- a/cypress/integration/controlOperations.js
+++ b/cypress/integration/controlOperations.js
@@ -1,7 +1,7 @@
 import { getTestConfig } from "../config";
 
 describe("Control operations", () => {
-  const { testUserMail, testPwd, newPwd } = getTestConfig();
+  const { testUserMail, testPwd } = getTestConfig();
 
   it("Login -> logout", () => {
     cy.visit("/signout");
@@ -22,17 +22,17 @@ describe("Control operations", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToChangePasswordForm();
     cy.get("div[data-cy=currentPassword] input").type(`${testPwd}`);
-    cy.get("div[data-cy=newPassword] input").type(`${newPwd}`);
-    cy.get("div[data-cy=confirmedPassword] input").type(`${newPwd}`);
+    cy.get("div[data-cy=newPassword] input").type(`${testPwd}`);
+    cy.get("div[data-cy=confirmedPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
     cy.get("p[data-cy=pwdChangeConfirmation").should("be.visible");
     // now change the password again to see it works and to ensure configured password is still valid
-    cy.reLogin(testUserMail, newPwd);
+    cy.reLogin(testUserMail, testPwd);
     cy.openAppDrawer();
     cy.get("a[data-cy=changePasswordDrawerButton]")
       .last()
       .click();
-    cy.get("div[data-cy=currentPassword] input").type(`${newPwd}`);
+    cy.get("div[data-cy=currentPassword] input").type(`${testPwd}`);
     cy.get("div[data-cy=newPassword] input").type(`${testPwd}`);
     cy.get("div[data-cy=confirmedPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
@@ -44,16 +44,16 @@ describe("Control operations", () => {
     cy.navigateToChangePasswordForm();
     // confirmedPassword empty
     cy.get("div[data-cy=currentPassword] input").type(`${testPwd}`);
-    cy.get("div[data-cy=newPassword] input").type(`${newPwd}`);
+    cy.get("div[data-cy=newPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click();
     cy.get("p[data-cy=pwdChangeConfirmation").should("not.be.visible");
     // newPassword empty
-    cy.get("div[data-cy=confirmedPassword] input").type(`${newPwd}`);
+    cy.get("div[data-cy=confirmedPassword] input").type(`${testPwd}`);
     cy.get("div[data-cy=newPassword] input").clear();
     cy.get("button[type=submit]").click();
     cy.get("p[data-cy=pwdChangeConfirmation").should("not.be.visible");
     // currentPassword empty
-    cy.get("div[data-cy=newPassword] input").type(`${newPwd}`);
+    cy.get("div[data-cy=newPassword] input").type(`${testPwd}`);
     cy.get("div[data-cy=currentPassword] input").clear();
     cy.get("button[type=submit]").click();
     cy.get("p[data-cy=pwdChangeConfirmation").should("not.be.visible");

--- a/cypress/integration/controlOperations.js
+++ b/cypress/integration/controlOperations.js
@@ -1,8 +1,7 @@
-import { getTestConfig, getChangePwdConfig } from "../config";
+import { getTestConfig } from "../config";
 
 describe("Control operations", () => {
-  const { testUserMail, testPwd } = getTestConfig();
-  const { changePwdUserMail, changePwdPwd, newPwd } = getChangePwdConfig();
+  const { testUserMail, testPwd, newPwd } = getTestConfig();
 
   it("Login -> logout", () => {
     cy.visit("/signout");
@@ -19,34 +18,32 @@ describe("Control operations", () => {
     cy.get("button[data-cy=signInButton]").should("exist"); // existing sign-in button means user is logged out
   });
 
-  // skipping, as this is causing other test failures when it fails
-  // by not restoring the password
-  it.skip("Change password -> Relogin -> Change password", () => {
-    cy.reLogin(changePwdUserMail, changePwdPwd);
+  it("Change password -> Relogin -> Change password", () => {
+    cy.reLogin(testUserMail, testPwd);
     cy.navigateToChangePasswordForm();
-    cy.get("div[data-cy=currentPassword] input").type(`${changePwdPwd}`);
+    cy.get("div[data-cy=currentPassword] input").type(`${testPwd}`);
     cy.get("div[data-cy=newPassword] input").type(`${newPwd}`);
     cy.get("div[data-cy=confirmedPassword] input").type(`${newPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
     cy.get("p[data-cy=pwdChangeConfirmation").should("be.visible");
     // now change the password again to see it works and to ensure configured password is still valid
-    cy.reLogin(changePwdUserMail, newPwd);
+    cy.reLogin(testUserMail, newPwd);
     cy.openAppDrawer();
     cy.get("a[data-cy=changePasswordDrawerButton]")
       .last()
       .click();
     cy.get("div[data-cy=currentPassword] input").type(`${newPwd}`);
-    cy.get("div[data-cy=newPassword] input").type(`${changePwdPwd}`);
-    cy.get("div[data-cy=confirmedPassword] input").type(`${changePwdPwd}`);
+    cy.get("div[data-cy=newPassword] input").type(`${testPwd}`);
+    cy.get("div[data-cy=confirmedPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
     cy.get("p[data-cy=pwdChangeConfirmation").should("be.visible");
   });
 
   it("Change password form cannot have any empty field", () => {
-    cy.reLogin(changePwdUserMail, changePwdPwd);
+    cy.reLogin(testUserMail, testPwd);
     cy.navigateToChangePasswordForm();
     // confirmedPassword empty
-    cy.get("div[data-cy=currentPassword] input").type(`${changePwdPwd}`);
+    cy.get("div[data-cy=currentPassword] input").type(`${testPwd}`);
     cy.get("div[data-cy=newPassword] input").type(`${newPwd}`);
     cy.get("button[type=submit]").click();
     cy.get("p[data-cy=pwdChangeConfirmation").should("not.be.visible");

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,12 +29,26 @@ Cypress.Commands.add("reLogin", (userMail, userPassword) => {
   cy.visit("/signout");
   cy.get("div[data-cy=email] input").type(`${userMail}`);
   cy.get("div[data-cy=password] input").type(`${userPassword}`);
-  cy.get("button[data-cy=signInButton]").click();
+  cy.get("button[data-cy=signInButton]").click({ timeout: 10000 });
 });
 
 Cypress.Commands.add("openAppDrawer", () => {
-  cy.get("button[data-cy=appDrawerOpener]").click();
-  cy.get("div[data-cy=appDrawerDiv]").should("be.visible");
+  cy.get("button[data-cy=appDrawerOpener]").should("be.visible");
+  cy.get("body").then($body => {
+    if ($body.find("button[data-cy=appDrawerOpener]").length > 0) {
+      cy.get("button[data-cy=appDrawerOpener]")
+        .click()
+        .then(() => {
+          cy.get("div[data-cy=appDrawerDiv]")
+            .last()
+            .should("be.visible");
+        });
+    } else {
+      cy.get("div[data-cy=appDrawerDiv]")
+        .last()
+        .should("be.visible");
+    }
+  });
 });
 
 Cypress.Commands.add("navigateToChangePasswordForm", () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,7 +29,8 @@ Cypress.Commands.add("reLogin", (userMail, userPassword) => {
   cy.visit("/signout");
   cy.get("div[data-cy=email] input").type(`${userMail}`);
   cy.get("div[data-cy=password] input").type(`${userPassword}`);
-  cy.get("button[data-cy=signInButton]").click({ timeout: 10000 });
+  cy.get("button[data-cy=signInButton]").click();
+  cy.location("pathname", { timeout: 10000 }).should("not.include", "/signin");
 });
 
 Cypress.Commands.add("openAppDrawer", () => {

--- a/src/modules/auth/containers/PrivateRoute.jsx
+++ b/src/modules/auth/containers/PrivateRoute.jsx
@@ -7,14 +7,17 @@ import Progress from "components/Progress";
 const mapStateToProps = ({ user }) => ({ user });
 
 export const PrivateRoute = ({ user, component: Component, ...props }) => {
-  const getComponent = () => {
-    if (user.loading || !user.hasInitialized) return <Progress />;
-
-    if (!user.data) return <Redirect to="/signin" />;
-
-    return <Component />;
-  };
-  return <Route component={getComponent} {...props} />;
+  const isSigningIn = user.loading || !user.hasInitialized;
+  const isNotSignedIn = !user.data;
+  // returning seperate routes based on auth state, rather than returning
+  // a single route and switching on the inner component as this seemed
+  // to cause the  entire application to re-mount whenever the 'user'
+  // state changes (so you'd lose state of forms)
+  // TODO: write test on this for change password?
+  if (isSigningIn) return <Route component={Progress} {...props} />;
+  if (isNotSignedIn)
+    return <Route component={() => <Redirect to="/signin" />} {...props} />;
+  return <Route component={Component} {...props} />;
 };
 
 export default connect(mapStateToProps)(PrivateRoute);


### PR DESCRIPTION
Fixing 3 issues:

- Reintroduced changePassword UI test with same password to avoid putting Db to faulty state
- reLogin sign-in click validates page transition by checking URL(pathname)
- conditional test for presence of appDrawer "hamburger" button to ensure navigation in UI works fine