### PR TITLE
Switch data-cy attributes to data-testid

### DIFF
--- a/cypress/integration/boxesTests.js
+++ b/cypress/integration/boxesTests.js
@@ -12,51 +12,51 @@ describe("CRUD boxes tests", () => {
   it("Create new box", () => {
     const testCount = Math.floor(Math.random() * 6) + 1;
     const testComment = uuidv4().substring(0, 6);
-    cy.get("[data-testid=makeBoxButton]").click();
-    cy.get("[data-testid=selectProduct]").click();
-    cy.get("[data-testid=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("[data-testid=productDropdownItem]")
+    cy.getByTestId("makeBoxButton").click();
+    cy.getByTestId("selectProduct").click();
+    cy.getByTestId("boxForm").should("exist"); // form to add box should pop up
+    cy.getByTestId("productDropdownItem")
       .first()
       .click();
-    cy.get("[data-testid=quantity] input").type(`${testCount}`);
-    cy.get("[data-testid=comment] textarea").type(`${testComment}`);
-    cy.get("[data-testid=submitCreateBox]")
+    cy.getInputContainedByTestId("quantity").type(`${testCount}`);
+    cy.getTextAreaContainedByTestId("comment").type(`${testComment}`);
+    cy.getByTestId("submitCreateBox")
       .click({ timeout: 10000 })
       .then(() => {
-        cy.get("h6[data-testid='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
+        cy.getByTestId("boxCreatedLabel").should("exist"); // "Box created" label with box details should be visible
       });
   });
 
   it("Create 2 boxes in a row updates overview of last added box", () => {
     const testCount = Math.floor(Math.random() * 6) + 1;
     const testComment = uuidv4().substring(0, 6);
-    cy.get("[data-testid=makeBoxButton]").click();
-    cy.get("[data-testid=selectProduct]").click();
-    cy.get("[data-testid=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("[data-testid=productDropdownItem]")
+    cy.getByTestId("makeBoxButton").click();
+    cy.getByTestId("selectProduct").click();
+    cy.getByTestId("boxForm").should("exist"); // form to add box should pop up
+    cy.getByTestId("productDropdownItem")
       .first()
       .click();
-    cy.get("[data-testid=quantity] input").type(`${testCount}`);
-    cy.get("[data-testid=comment] textarea").type(`${testComment}`);
-    cy.get("[data-testid=submitCreateBox]").click({ timeout: 10000 });
+    cy.getInputContainedByTestId("quantity").type(`${testCount}`);
+    cy.getTextAreaContainedByTestId("comment").type(`${testComment}`);
+    cy.getByTestId("submitCreateBox").click({ timeout: 10000 });
 
-    cy.get("h6[data-testid='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
-    cy.get("h6[data-testid='boxCreatedQuantityLabel']").should(
+    cy.getByTestId("boxCreatedLabel").should("exist"); // "Box created" label with box details should be visible
+    cy.getByTestId("boxCreatedQuantityLabel").should(
       "contain",
       `${testCount}x`
     ); // count of items should be displayed
-    cy.get("[data-testid='createAnotherBoxButton']").click();
-    cy.get("[data-testid=selectProduct]").click();
-    cy.get("[data-testid=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("[data-testid=productDropdownItem]")
+    cy.getByTestId("createAnotherBoxButton").click();
+    cy.getByTestId("selectProduct").click();
+    cy.getByTestId("boxForm").should("exist"); // form to add box should pop up
+    cy.getByTestId("productDropdownItem")
       .first()
       .click();
-    cy.get("[data-testid=quantity] input").type(`${testCount + 1}`);
-    cy.get("[data-testid=comment] textarea").type(`${testComment}`);
-    cy.get("[data-testid=submitCreateBox]").click({ timeout: 10000 });
+    cy.getInputContainedByTestId("quantity").type(`${testCount + 1}`);
+    cy.getTextAreaContainedByTestId("comment").type(`${testComment}`);
+    cy.getByTestId("submitCreateBox").click({ timeout: 10000 });
 
-    cy.get("h6[data-testid='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
-    cy.get("h6[data-testid='boxCreatedQuantityLabel']").should(
+    cy.getByTestId("boxCreatedLabel").should("exist"); // "Box created" label with box details should be visible
+    cy.getByTestId("boxCreatedQuantityLabel").should(
       "contain",
       `${testCount + 1}x`
     ); // updated count of items should be displayed
@@ -64,15 +64,15 @@ describe("CRUD boxes tests", () => {
 
   it("Number of items during box creation has to be specified", () => {
     const testComment = uuidv4().substring(0, 6);
-    cy.get("[data-testid=makeBoxButton]").should("be.visible");
-    cy.get("[data-testid=makeBoxButton]").click();
-    cy.get("[data-testid=selectProduct]").click();
-    cy.get("[data-testid=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("[data-testid=productDropdownItem]")
+    cy.getByTestId("makeBoxButton").should("be.visible");
+    cy.getByTestId("makeBoxButton").click();
+    cy.getByTestId("selectProduct").click();
+    cy.getByTestId("boxForm").should("exist"); // form to add box should pop up
+    cy.getByTestId("productDropdownItem")
       .first()
       .click();
-    cy.get("[data-testid=comment] textarea").type(`${testComment}`);
-    cy.get("[data-testid=submitCreateBox]").click({ timeout: 10000 });
-    cy.get("[data-testid=quantity] input").should("exist"); // number of items input should be visible
+    cy.getTextAreaContainedByTestId("comment").type(`${testComment}`);
+    cy.getByTestId("submitCreateBox").click({ timeout: 10000 });
+    cy.getInputContainedByTestId("quantity").should("exist"); // number of items input should be visible
   });
 });

--- a/cypress/integration/boxesTests.js
+++ b/cypress/integration/boxesTests.js
@@ -1,4 +1,5 @@
 import uuidv4 from "uuid/v4";
+
 import { getTestConfig } from "../config";
 
 describe("CRUD boxes tests", () => {
@@ -37,32 +38,28 @@ describe("CRUD boxes tests", () => {
       .click();
     cy.get("div[data-cy=quantity] input").type(`${testCount}`);
     cy.get("div[data-cy=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-cy=submitCreateBox]")
-      .click({ timeout: 10000 })
-      .then(() => {
-        cy.get("h6[data-cy='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
-        cy.get("h6[data-cy='boxCreatedQuantityLabel']").should(
-          "contain",
-          `${testCount}x`
-        ); // count of items should be displayed
-        cy.get("button[data-cy='createAnotherBoxButton']").click();
-        cy.get("div[data-cy=selectProduct]").click();
-        cy.get("form[data-cy=boxForm]").should("exist"); // form to add box should pop up
-        cy.get("li[data-cy=productDropdownItem]")
-          .first()
-          .click();
-        cy.get("div[data-cy=quantity] input").type(`${testCount + 1}`);
-        cy.get("div[data-cy=comment] textarea").type(`${testComment}`);
-        cy.get("button[data-cy=submitCreateBox]")
-          .click({ timeout: 10000 })
-          .then(() => {
-            cy.get("h6[data-cy='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
-            cy.get("h6[data-cy='boxCreatedQuantityLabel']").should(
-              "contain",
-              `${testCount + 1}x`
-            ); // updated count of items should be displayed
-          });
-      });
+    cy.get("button[data-cy=submitCreateBox]").click({ timeout: 10000 });
+
+    cy.get("h6[data-cy='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
+    cy.get("h6[data-cy='boxCreatedQuantityLabel']").should(
+      "contain",
+      `${testCount}x`
+    ); // count of items should be displayed
+    cy.get("button[data-cy='createAnotherBoxButton']").click();
+    cy.get("div[data-cy=selectProduct]").click();
+    cy.get("form[data-cy=boxForm]").should("exist"); // form to add box should pop up
+    cy.get("li[data-cy=productDropdownItem]")
+      .first()
+      .click();
+    cy.get("div[data-cy=quantity] input").type(`${testCount + 1}`);
+    cy.get("div[data-cy=comment] textarea").type(`${testComment}`);
+    cy.get("button[data-cy=submitCreateBox]").click({ timeout: 10000 });
+
+    cy.get("h6[data-cy='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
+    cy.get("h6[data-cy='boxCreatedQuantityLabel']").should(
+      "contain",
+      `${testCount + 1}x`
+    ); // updated count of items should be displayed
   });
 
   it("Number of items during box creation has to be specified", () => {
@@ -75,10 +72,7 @@ describe("CRUD boxes tests", () => {
       .first()
       .click();
     cy.get("div[data-cy=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-cy=submitCreateBox]")
-      .click({ timeout: 10000 })
-      .then(() => {
-        cy.get("div[data-cy=quantity] input").should("exist"); // number of items input should be visible
-      });
+    cy.get("button[data-cy=submitCreateBox]").click({ timeout: 10000 });
+    cy.get("div[data-cy=quantity] input").should("exist"); // number of items input should be visible
   });
 });

--- a/cypress/integration/boxesTests.js
+++ b/cypress/integration/boxesTests.js
@@ -12,15 +12,15 @@ describe("CRUD boxes tests", () => {
   it("Create new box", () => {
     const testCount = Math.floor(Math.random() * 6) + 1;
     const testComment = uuidv4().substring(0, 6);
-    cy.get("button[data-testid=makeBoxButton]").click();
-    cy.get("div[data-testid=selectProduct]").click();
-    cy.get("form[data-testid=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("li[data-testid=productDropdownItem]")
+    cy.get("[data-testid=makeBoxButton]").click();
+    cy.get("[data-testid=selectProduct]").click();
+    cy.get("[data-testid=boxForm]").should("exist"); // form to add box should pop up
+    cy.get("[data-testid=productDropdownItem]")
       .first()
       .click();
-    cy.get("div[data-testid=quantity] input").type(`${testCount}`);
-    cy.get("div[data-testid=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-testid=submitCreateBox]")
+    cy.get("[data-testid=quantity] input").type(`${testCount}`);
+    cy.get("[data-testid=comment] textarea").type(`${testComment}`);
+    cy.get("[data-testid=submitCreateBox]")
       .click({ timeout: 10000 })
       .then(() => {
         cy.get("h6[data-testid='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
@@ -30,30 +30,30 @@ describe("CRUD boxes tests", () => {
   it("Create 2 boxes in a row updates overview of last added box", () => {
     const testCount = Math.floor(Math.random() * 6) + 1;
     const testComment = uuidv4().substring(0, 6);
-    cy.get("button[data-testid=makeBoxButton]").click();
-    cy.get("div[data-testid=selectProduct]").click();
-    cy.get("form[data-testid=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("li[data-testid=productDropdownItem]")
+    cy.get("[data-testid=makeBoxButton]").click();
+    cy.get("[data-testid=selectProduct]").click();
+    cy.get("[data-testid=boxForm]").should("exist"); // form to add box should pop up
+    cy.get("[data-testid=productDropdownItem]")
       .first()
       .click();
-    cy.get("div[data-testid=quantity] input").type(`${testCount}`);
-    cy.get("div[data-testid=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-testid=submitCreateBox]").click({ timeout: 10000 });
+    cy.get("[data-testid=quantity] input").type(`${testCount}`);
+    cy.get("[data-testid=comment] textarea").type(`${testComment}`);
+    cy.get("[data-testid=submitCreateBox]").click({ timeout: 10000 });
 
     cy.get("h6[data-testid='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
     cy.get("h6[data-testid='boxCreatedQuantityLabel']").should(
       "contain",
       `${testCount}x`
     ); // count of items should be displayed
-    cy.get("button[data-testid='createAnotherBoxButton']").click();
-    cy.get("div[data-testid=selectProduct]").click();
-    cy.get("form[data-testid=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("li[data-testid=productDropdownItem]")
+    cy.get("[data-testid='createAnotherBoxButton']").click();
+    cy.get("[data-testid=selectProduct]").click();
+    cy.get("[data-testid=boxForm]").should("exist"); // form to add box should pop up
+    cy.get("[data-testid=productDropdownItem]")
       .first()
       .click();
-    cy.get("div[data-testid=quantity] input").type(`${testCount + 1}`);
-    cy.get("div[data-testid=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-testid=submitCreateBox]").click({ timeout: 10000 });
+    cy.get("[data-testid=quantity] input").type(`${testCount + 1}`);
+    cy.get("[data-testid=comment] textarea").type(`${testComment}`);
+    cy.get("[data-testid=submitCreateBox]").click({ timeout: 10000 });
 
     cy.get("h6[data-testid='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
     cy.get("h6[data-testid='boxCreatedQuantityLabel']").should(
@@ -64,15 +64,15 @@ describe("CRUD boxes tests", () => {
 
   it("Number of items during box creation has to be specified", () => {
     const testComment = uuidv4().substring(0, 6);
-    cy.get("button[data-testid=makeBoxButton]").should("be.visible");
-    cy.get("button[data-testid=makeBoxButton]").click();
-    cy.get("div[data-testid=selectProduct]").click();
-    cy.get("form[data-testid=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("li[data-testid=productDropdownItem]")
+    cy.get("[data-testid=makeBoxButton]").should("be.visible");
+    cy.get("[data-testid=makeBoxButton]").click();
+    cy.get("[data-testid=selectProduct]").click();
+    cy.get("[data-testid=boxForm]").should("exist"); // form to add box should pop up
+    cy.get("[data-testid=productDropdownItem]")
       .first()
       .click();
-    cy.get("div[data-testid=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-testid=submitCreateBox]").click({ timeout: 10000 });
-    cy.get("div[data-testid=quantity] input").should("exist"); // number of items input should be visible
+    cy.get("[data-testid=comment] textarea").type(`${testComment}`);
+    cy.get("[data-testid=submitCreateBox]").click({ timeout: 10000 });
+    cy.get("[data-testid=quantity] input").should("exist"); // number of items input should be visible
   });
 });

--- a/cypress/integration/boxesTests.js
+++ b/cypress/integration/boxesTests.js
@@ -12,51 +12,51 @@ describe("CRUD boxes tests", () => {
   it("Create new box", () => {
     const testCount = Math.floor(Math.random() * 6) + 1;
     const testComment = uuidv4().substring(0, 6);
-    cy.get("button[data-cy=makeBoxButton]").click();
-    cy.get("div[data-cy=selectProduct]").click();
-    cy.get("form[data-cy=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("li[data-cy=productDropdownItem]")
+    cy.get("button[data-testid=makeBoxButton]").click();
+    cy.get("div[data-testid=selectProduct]").click();
+    cy.get("form[data-testid=boxForm]").should("exist"); // form to add box should pop up
+    cy.get("li[data-testid=productDropdownItem]")
       .first()
       .click();
-    cy.get("div[data-cy=quantity] input").type(`${testCount}`);
-    cy.get("div[data-cy=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-cy=submitCreateBox]")
+    cy.get("div[data-testid=quantity] input").type(`${testCount}`);
+    cy.get("div[data-testid=comment] textarea").type(`${testComment}`);
+    cy.get("button[data-testid=submitCreateBox]")
       .click({ timeout: 10000 })
       .then(() => {
-        cy.get("h6[data-cy='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
+        cy.get("h6[data-testid='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
       });
   });
 
   it("Create 2 boxes in a row updates overview of last added box", () => {
     const testCount = Math.floor(Math.random() * 6) + 1;
     const testComment = uuidv4().substring(0, 6);
-    cy.get("button[data-cy=makeBoxButton]").click();
-    cy.get("div[data-cy=selectProduct]").click();
-    cy.get("form[data-cy=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("li[data-cy=productDropdownItem]")
+    cy.get("button[data-testid=makeBoxButton]").click();
+    cy.get("div[data-testid=selectProduct]").click();
+    cy.get("form[data-testid=boxForm]").should("exist"); // form to add box should pop up
+    cy.get("li[data-testid=productDropdownItem]")
       .first()
       .click();
-    cy.get("div[data-cy=quantity] input").type(`${testCount}`);
-    cy.get("div[data-cy=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-cy=submitCreateBox]").click({ timeout: 10000 });
+    cy.get("div[data-testid=quantity] input").type(`${testCount}`);
+    cy.get("div[data-testid=comment] textarea").type(`${testComment}`);
+    cy.get("button[data-testid=submitCreateBox]").click({ timeout: 10000 });
 
-    cy.get("h6[data-cy='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
-    cy.get("h6[data-cy='boxCreatedQuantityLabel']").should(
+    cy.get("h6[data-testid='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
+    cy.get("h6[data-testid='boxCreatedQuantityLabel']").should(
       "contain",
       `${testCount}x`
     ); // count of items should be displayed
-    cy.get("button[data-cy='createAnotherBoxButton']").click();
-    cy.get("div[data-cy=selectProduct]").click();
-    cy.get("form[data-cy=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("li[data-cy=productDropdownItem]")
+    cy.get("button[data-testid='createAnotherBoxButton']").click();
+    cy.get("div[data-testid=selectProduct]").click();
+    cy.get("form[data-testid=boxForm]").should("exist"); // form to add box should pop up
+    cy.get("li[data-testid=productDropdownItem]")
       .first()
       .click();
-    cy.get("div[data-cy=quantity] input").type(`${testCount + 1}`);
-    cy.get("div[data-cy=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-cy=submitCreateBox]").click({ timeout: 10000 });
+    cy.get("div[data-testid=quantity] input").type(`${testCount + 1}`);
+    cy.get("div[data-testid=comment] textarea").type(`${testComment}`);
+    cy.get("button[data-testid=submitCreateBox]").click({ timeout: 10000 });
 
-    cy.get("h6[data-cy='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
-    cy.get("h6[data-cy='boxCreatedQuantityLabel']").should(
+    cy.get("h6[data-testid='boxCreatedLabel']").should("exist"); // "Box created" label with box details should be visible
+    cy.get("h6[data-testid='boxCreatedQuantityLabel']").should(
       "contain",
       `${testCount + 1}x`
     ); // updated count of items should be displayed
@@ -64,15 +64,15 @@ describe("CRUD boxes tests", () => {
 
   it("Number of items during box creation has to be specified", () => {
     const testComment = uuidv4().substring(0, 6);
-    cy.get("button[data-cy=makeBoxButton]").should("be.visible");
-    cy.get("button[data-cy=makeBoxButton]").click();
-    cy.get("div[data-cy=selectProduct]").click();
-    cy.get("form[data-cy=boxForm]").should("exist"); // form to add box should pop up
-    cy.get("li[data-cy=productDropdownItem]")
+    cy.get("button[data-testid=makeBoxButton]").should("be.visible");
+    cy.get("button[data-testid=makeBoxButton]").click();
+    cy.get("div[data-testid=selectProduct]").click();
+    cy.get("form[data-testid=boxForm]").should("exist"); // form to add box should pop up
+    cy.get("li[data-testid=productDropdownItem]")
       .first()
       .click();
-    cy.get("div[data-cy=comment] textarea").type(`${testComment}`);
-    cy.get("button[data-cy=submitCreateBox]").click({ timeout: 10000 });
-    cy.get("div[data-cy=quantity] input").should("exist"); // number of items input should be visible
+    cy.get("div[data-testid=comment] textarea").type(`${testComment}`);
+    cy.get("button[data-testid=submitCreateBox]").click({ timeout: 10000 });
+    cy.get("div[data-testid=quantity] input").should("exist"); // number of items input should be visible
   });
 });

--- a/cypress/integration/boxesTests.js
+++ b/cypress/integration/boxesTests.js
@@ -20,11 +20,8 @@ describe("CRUD boxes tests", () => {
       .click();
     cy.getInputContainedByTestId("quantity").type(`${testCount}`);
     cy.getTextAreaContainedByTestId("comment").type(`${testComment}`);
-    cy.getByTestId("submitCreateBox")
-      .click({ timeout: 10000 })
-      .then(() => {
-        cy.getByTestId("boxCreatedLabel").should("exist"); // "Box created" label with box details should be visible
-      });
+    cy.getByTestId("submitCreateBox").click({ timeout: 10000 });
+    cy.getByTestId("boxCreatedLabel").should("exist"); // "Box created" label with box details should be visible
   });
 
   it("Create 2 boxes in a row updates overview of last added box", () => {

--- a/cypress/integration/controlOperations.js
+++ b/cypress/integration/controlOperations.js
@@ -5,64 +5,64 @@ describe("Control operations", () => {
 
   it("Login -> logout", () => {
     cy.visit("/signout");
-    cy.get("div[data-cy=email] input").type(`${testUserMail}`);
-    cy.get("div[data-cy=password] input").type(`${testPwd}`);
-    cy.get("button[data-cy=signInButton]").click({ timeout: 10000 });
-    cy.get("button[data-cy=makeBoxButton]").should("exist");
-    cy.get("a[data-cy=findBoxesButton]").should("exist");
-    cy.get("button[data-cy=appDrawerOpener]").should("exist");
+    cy.get("div[data-testid=email] input").type(`${testUserMail}`);
+    cy.get("div[data-testid=password] input").type(`${testPwd}`);
+    cy.get("button[data-testid=signInButton]").click({ timeout: 10000 });
+    cy.get("button[data-testid=makeBoxButton]").should("exist");
+    cy.get("a[data-testid=findBoxesButton]").should("exist");
+    cy.get("button[data-testid=appDrawerOpener]").should("exist");
     cy.openAppDrawer();
-    cy.get("a[data-cy=signoutDrawerButton]")
+    cy.get("a[data-testid=signoutDrawerButton]")
       .last()
       .click();
-    cy.get("button[data-cy=signInButton]").should("exist"); // existing sign-in button means user is logged out
+    cy.get("button[data-testid=signInButton]").should("exist"); // existing sign-in button means user is logged out
   });
 
   it("Change password -> Relogin -> Change password", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToChangePasswordForm();
-    cy.get("div[data-cy=currentPassword] input").type(`${testPwd}`);
-    cy.get("div[data-cy=newPassword] input").type(`${testPwd}`);
-    cy.get("div[data-cy=confirmedPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=currentPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=newPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=confirmedPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
-    cy.get("p[data-cy=pwdChangeConfirmation").should("be.visible");
+    cy.get("p[data-testid=pwdChangeConfirmation").should("be.visible");
     // now change the password again to see it works and to ensure configured password is still valid
     cy.reLogin(testUserMail, testPwd);
     cy.openAppDrawer();
-    cy.get("a[data-cy=changePasswordDrawerButton]")
+    cy.get("a[data-testid=changePasswordDrawerButton]")
       .last()
       .click();
-    cy.get("div[data-cy=currentPassword] input").type(`${testPwd}`);
-    cy.get("div[data-cy=newPassword] input").type(`${testPwd}`);
-    cy.get("div[data-cy=confirmedPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=currentPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=newPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=confirmedPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
-    cy.get("p[data-cy=pwdChangeConfirmation").should("be.visible");
+    cy.get("p[data-testid=pwdChangeConfirmation").should("be.visible");
   });
 
   it("Change password form cannot have any empty field", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToChangePasswordForm();
     // confirmedPassword empty
-    cy.get("div[data-cy=currentPassword] input").type(`${testPwd}`);
-    cy.get("div[data-cy=newPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=currentPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=newPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click();
-    cy.get("p[data-cy=pwdChangeConfirmation").should("not.be.visible");
+    cy.get("p[data-testid=pwdChangeConfirmation").should("not.be.visible");
     // newPassword empty
-    cy.get("div[data-cy=confirmedPassword] input").type(`${testPwd}`);
-    cy.get("div[data-cy=newPassword] input").clear();
+    cy.get("div[data-testid=confirmedPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=newPassword] input").clear();
     cy.get("button[type=submit]").click();
-    cy.get("p[data-cy=pwdChangeConfirmation").should("not.be.visible");
+    cy.get("p[data-testid=pwdChangeConfirmation").should("not.be.visible");
     // currentPassword empty
-    cy.get("div[data-cy=newPassword] input").type(`${testPwd}`);
-    cy.get("div[data-cy=currentPassword] input").clear();
+    cy.get("div[data-testid=newPassword] input").type(`${testPwd}`);
+    cy.get("div[data-testid=currentPassword] input").clear();
     cy.get("button[type=submit]").click();
-    cy.get("p[data-cy=pwdChangeConfirmation").should("not.be.visible");
+    cy.get("p[data-testid=pwdChangeConfirmation").should("not.be.visible");
   });
 
   it("Invite", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToInvitePage();
-    cy.get("button[data-cy=copyToClipboardButton]").should("be.visible");
+    cy.get("button[data-testid=copyToClipboardButton]").should("be.visible");
     // cypress opens an alert to confirm copying to clipboard - not sure what to do here (how to confirm it automatically)
     // const stub = cy.stub();
     // cy.on('window:alert', stub);

--- a/cypress/integration/controlOperations.js
+++ b/cypress/integration/controlOperations.js
@@ -5,64 +5,64 @@ describe("Control operations", () => {
 
   it("Login -> logout", () => {
     cy.visit("/signout");
-    cy.get("div[data-testid=email] input").type(`${testUserMail}`);
-    cy.get("div[data-testid=password] input").type(`${testPwd}`);
-    cy.get("button[data-testid=signInButton]").click({ timeout: 10000 });
-    cy.get("button[data-testid=makeBoxButton]").should("exist");
-    cy.get("a[data-testid=findBoxesButton]").should("exist");
-    cy.get("button[data-testid=appDrawerOpener]").should("exist");
+    cy.get("[data-testid=email] input").type(`${testUserMail}`);
+    cy.get("[data-testid=password] input").type(`${testPwd}`);
+    cy.get("[data-testid=signInButton]").click({ timeout: 10000 });
+    cy.get("[data-testid=makeBoxButton]").should("exist");
+    cy.get("[data-testid=findBoxesButton]").should("exist");
+    cy.get("[data-testid=appDrawerOpener]").should("exist");
     cy.openAppDrawer();
-    cy.get("a[data-testid=signoutDrawerButton]")
+    cy.get("[data-testid=signoutDrawerButton]")
       .last()
       .click();
-    cy.get("button[data-testid=signInButton]").should("exist"); // existing sign-in button means user is logged out
+    cy.get("[data-testid=signInButton]").should("exist"); // existing sign-in button means user is logged out
   });
 
   it("Change password -> Relogin -> Change password", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToChangePasswordForm();
-    cy.get("div[data-testid=currentPassword] input").type(`${testPwd}`);
-    cy.get("div[data-testid=newPassword] input").type(`${testPwd}`);
-    cy.get("div[data-testid=confirmedPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=currentPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=newPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=confirmedPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
-    cy.get("p[data-testid=pwdChangeConfirmation").should("be.visible");
+    cy.get("[data-testid=pwdChangeConfirmation").should("be.visible");
     // now change the password again to see it works and to ensure configured password is still valid
     cy.reLogin(testUserMail, testPwd);
     cy.openAppDrawer();
-    cy.get("a[data-testid=changePasswordDrawerButton]")
+    cy.get("[data-testid=changePasswordDrawerButton]")
       .last()
       .click();
-    cy.get("div[data-testid=currentPassword] input").type(`${testPwd}`);
-    cy.get("div[data-testid=newPassword] input").type(`${testPwd}`);
-    cy.get("div[data-testid=confirmedPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=currentPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=newPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=confirmedPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
-    cy.get("p[data-testid=pwdChangeConfirmation").should("be.visible");
+    cy.get("[data-testid=pwdChangeConfirmation").should("be.visible");
   });
 
   it("Change password form cannot have any empty field", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToChangePasswordForm();
     // confirmedPassword empty
-    cy.get("div[data-testid=currentPassword] input").type(`${testPwd}`);
-    cy.get("div[data-testid=newPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=currentPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=newPassword] input").type(`${testPwd}`);
     cy.get("button[type=submit]").click();
-    cy.get("p[data-testid=pwdChangeConfirmation").should("not.be.visible");
+    cy.get("[data-testid=pwdChangeConfirmation").should("not.be.visible");
     // newPassword empty
-    cy.get("div[data-testid=confirmedPassword] input").type(`${testPwd}`);
-    cy.get("div[data-testid=newPassword] input").clear();
+    cy.get("[data-testid=confirmedPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=newPassword] input").clear();
     cy.get("button[type=submit]").click();
-    cy.get("p[data-testid=pwdChangeConfirmation").should("not.be.visible");
+    cy.get("[data-testid=pwdChangeConfirmation").should("not.be.visible");
     // currentPassword empty
-    cy.get("div[data-testid=newPassword] input").type(`${testPwd}`);
-    cy.get("div[data-testid=currentPassword] input").clear();
+    cy.get("[data-testid=newPassword] input").type(`${testPwd}`);
+    cy.get("[data-testid=currentPassword] input").clear();
     cy.get("button[type=submit]").click();
-    cy.get("p[data-testid=pwdChangeConfirmation").should("not.be.visible");
+    cy.get("[data-testid=pwdChangeConfirmation").should("not.be.visible");
   });
 
   it("Invite", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToInvitePage();
-    cy.get("button[data-testid=copyToClipboardButton]").should("be.visible");
+    cy.get("[data-testid=copyToClipboardButton]").should("be.visible");
     // cypress opens an alert to confirm copying to clipboard - not sure what to do here (how to confirm it automatically)
     // const stub = cy.stub();
     // cy.on('window:alert', stub);

--- a/cypress/integration/controlOperations.js
+++ b/cypress/integration/controlOperations.js
@@ -5,64 +5,64 @@ describe("Control operations", () => {
 
   it("Login -> logout", () => {
     cy.visit("/signout");
-    cy.get("[data-testid=email] input").type(`${testUserMail}`);
-    cy.get("[data-testid=password] input").type(`${testPwd}`);
-    cy.get("[data-testid=signInButton]").click({ timeout: 10000 });
-    cy.get("[data-testid=makeBoxButton]").should("exist");
-    cy.get("[data-testid=findBoxesButton]").should("exist");
-    cy.get("[data-testid=appDrawerOpener]").should("exist");
+    cy.getInputContainedByTestId("email").type(`${testUserMail}`);
+    cy.getInputContainedByTestId("password").type(`${testPwd}`);
+    cy.getByTestId("signInButton").click({ timeout: 10000 });
+    cy.getByTestId("makeBoxButton").should("exist");
+    cy.getByTestId("findBoxesButton").should("exist");
+    cy.getByTestId("appDrawerOpener").should("exist");
     cy.openAppDrawer();
-    cy.get("[data-testid=signoutDrawerButton]")
+    cy.getByTestId("signoutDrawerButton")
       .last()
       .click();
-    cy.get("[data-testid=signInButton]").should("exist"); // existing sign-in button means user is logged out
+    cy.getByTestId("signInButton").should("exist"); // existing sign-in button means user is logged out
   });
 
   it("Change password -> Relogin -> Change password", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToChangePasswordForm();
-    cy.get("[data-testid=currentPassword] input").type(`${testPwd}`);
-    cy.get("[data-testid=newPassword] input").type(`${testPwd}`);
-    cy.get("[data-testid=confirmedPassword] input").type(`${testPwd}`);
+    cy.getInputContainedByTestId("currentPassword").type(`${testPwd}`);
+    cy.getInputContainedByTestId("newPassword").type(`${testPwd}`);
+    cy.getInputContainedByTestId("confirmedPassword").type(`${testPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
-    cy.get("[data-testid=pwdChangeConfirmation").should("be.visible");
+    cy.getByTestId("pwdChangeConfirmation").should("be.visible");
     // now change the password again to see it works and to ensure configured password is still valid
     cy.reLogin(testUserMail, testPwd);
     cy.openAppDrawer();
-    cy.get("[data-testid=changePasswordDrawerButton]")
+    cy.getByTestId("changePasswordDrawerButton")
       .last()
       .click();
-    cy.get("[data-testid=currentPassword] input").type(`${testPwd}`);
-    cy.get("[data-testid=newPassword] input").type(`${testPwd}`);
-    cy.get("[data-testid=confirmedPassword] input").type(`${testPwd}`);
+    cy.getInputContainedByTestId("currentPassword").type(`${testPwd}`);
+    cy.getInputContainedByTestId("newPassword").type(`${testPwd}`);
+    cy.getInputContainedByTestId("confirmedPassword").type(`${testPwd}`);
     cy.get("button[type=submit]").click({ timeout: 10000 });
-    cy.get("[data-testid=pwdChangeConfirmation").should("be.visible");
+    cy.getByTestId("pwdChangeConfirmation").should("be.visible");
   });
 
   it("Change password form cannot have any empty field", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToChangePasswordForm();
     // confirmedPassword empty
-    cy.get("[data-testid=currentPassword] input").type(`${testPwd}`);
-    cy.get("[data-testid=newPassword] input").type(`${testPwd}`);
+    cy.getInputContainedByTestId("currentPassword").type(`${testPwd}`);
+    cy.getInputContainedByTestId("newPassword").type(`${testPwd}`);
     cy.get("button[type=submit]").click();
-    cy.get("[data-testid=pwdChangeConfirmation").should("not.be.visible");
+    cy.getByTestId("pwdChangeConfirmation").should("not.be.visible");
     // newPassword empty
-    cy.get("[data-testid=confirmedPassword] input").type(`${testPwd}`);
-    cy.get("[data-testid=newPassword] input").clear();
+    cy.getInputContainedByTestId("confirmedPassword").type(`${testPwd}`);
+    cy.getInputContainedByTestId("newPassword").clear();
     cy.get("button[type=submit]").click();
-    cy.get("[data-testid=pwdChangeConfirmation").should("not.be.visible");
+    cy.getByTestId("pwdChangeConfirmation").should("not.be.visible");
     // currentPassword empty
-    cy.get("[data-testid=newPassword] input").type(`${testPwd}`);
-    cy.get("[data-testid=currentPassword] input").clear();
+    cy.getInputContainedByTestId("newPassword").type(`${testPwd}`);
+    cy.getInputContainedByTestId("currentPassword").clear();
     cy.get("button[type=submit]").click();
-    cy.get("[data-testid=pwdChangeConfirmation").should("not.be.visible");
+    cy.getByTestId("pwdChangeConfirmation").should("not.be.visible");
   });
 
   it("Invite", () => {
     cy.reLogin(testUserMail, testPwd);
     cy.navigateToInvitePage();
-    cy.get("[data-testid=copyToClipboardButton]").should("be.visible");
+    cy.getByTestId("copyToClipboardButton").should("be.visible");
     // cypress opens an alert to confirm copying to clipboard - not sure what to do here (how to confirm it automatically)
     // const stub = cy.stub();
     // cy.on('window:alert', stub);

--- a/cypress/integration/productsTests.js
+++ b/cypress/integration/productsTests.js
@@ -19,18 +19,18 @@ describe("CRUD products tests", () => {
   // We're expecting this test to fail once pagination of tables gets implemented
   it("'Delete product' removes one row from table", () => {
     cy.navigateToProductsPage();
-    cy.get("[data-testid=productsTableBody")
+    cy.getByTestId("productsTableBody")
       .find("tr")
       .its("length")
       .then(rowsBefore => {
-        cy.get("[data-testid=deleteProductButton]")
+        cy.getByTestId("deleteProductButton")
           .first()
           .click();
-        cy.get("[data-testid=deleteConfirmationDialog").should("be.visible");
-        cy.get("[data-testid=confirmDeleteButton").click();
+        cy.getByTestId("deleteConfirmationDialog").should("be.visible");
+        cy.getByTestId("confirmDeleteButton").click();
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(2000); // updating table takes some time
-        cy.get("[data-testid=productsTableBody")
+        cy.getByTestId("productsTableBody")
           .find("tr")
           .its("length")
           .as("rowsAfter");
@@ -40,7 +40,7 @@ describe("CRUD products tests", () => {
 
   it("'Delete product' lowers count of products with same name by 1", () => {
     cy.navigateToProductsPage();
-    cy.get("[data-testid=productNameCell]")
+    cy.getByTestId("productNameCell")
       .first()
       .invoke("text")
       .as("firstProductName")
@@ -49,13 +49,11 @@ describe("CRUD products tests", () => {
           .its("length")
           .as("sameNameCountBefore")
           .then(sameNameCountBefore => {
-            cy.get("[data-testid=deleteProductButton]")
+            cy.getByTestId("deleteProductButton")
               .first()
               .click();
-            cy.get("[data-testid=deleteConfirmationDialog").should(
-              "be.visible"
-            );
-            cy.get("[data-testid=confirmDeleteButton").click();
+            cy.getByTestId("deleteConfirmationDialog").should("be.visible");
+            cy.getByTestId("confirmDeleteButton").click();
             // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(2000); // updating table takes some time
             if (sameNameCountBefore === 1) {
@@ -76,17 +74,17 @@ describe("CRUD products tests", () => {
   it("Edit product", () => {
     const newName = uuidv4().substring(0, 6);
     cy.navigateToProductsPage();
-    cy.get("[data-testid=editProductButton]")
+    cy.getByTestId("editProductButton")
       .first()
       .click();
-    cy.get("[data-testid=productDialog").should("be.visible");
-    cy.get("[data-testid=productName] input")
+    cy.getByTestId("productDialog").should("be.visible");
+    cy.getInputContainedByTestId("productName")
       .clear()
       .type(newName);
-    cy.get("[data-testid=submitCreateProduct")
+    cy.getByTestId("submitCreateProduct")
       .click()
       .then(() => {
-        cy.get("[data-testid=productNameCell]")
+        cy.getByTestId("productNameCell")
           .first()
           .invoke("text")
           .should("equal", newName);

--- a/cypress/integration/productsTests.js
+++ b/cypress/integration/productsTests.js
@@ -19,18 +19,18 @@ describe("CRUD products tests", () => {
   // We're expecting this test to fail once pagination of tables gets implemented
   it("'Delete product' removes one row from table", () => {
     cy.navigateToProductsPage();
-    cy.get("tbody[data-cy=productsTableBody")
+    cy.get("tbody[data-testid=productsTableBody")
       .find("tr")
       .its("length")
       .then(rowsBefore => {
-        cy.get("button[data-cy=deleteProductButton]")
+        cy.get("button[data-testid=deleteProductButton]")
           .first()
           .click();
-        cy.get("div[data-cy=deleteConfirmationDialog").should("be.visible");
-        cy.get("button[data-cy=confirmDeleteButton").click();
+        cy.get("div[data-testid=deleteConfirmationDialog").should("be.visible");
+        cy.get("button[data-testid=confirmDeleteButton").click();
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(2000); // updating table takes some time
-        cy.get("tbody[data-cy=productsTableBody")
+        cy.get("tbody[data-testid=productsTableBody")
           .find("tr")
           .its("length")
           .as("rowsAfter");
@@ -40,7 +40,7 @@ describe("CRUD products tests", () => {
 
   it("'Delete product' lowers count of products with same name by 1", () => {
     cy.navigateToProductsPage();
-    cy.get("td[data-cy=productNameCell]")
+    cy.get("td[data-testid=productNameCell]")
       .first()
       .invoke("text")
       .as("firstProductName")
@@ -49,11 +49,13 @@ describe("CRUD products tests", () => {
           .its("length")
           .as("sameNameCountBefore")
           .then(sameNameCountBefore => {
-            cy.get("button[data-cy=deleteProductButton]")
+            cy.get("button[data-testid=deleteProductButton]")
               .first()
               .click();
-            cy.get("div[data-cy=deleteConfirmationDialog").should("be.visible");
-            cy.get("button[data-cy=confirmDeleteButton").click();
+            cy.get("div[data-testid=deleteConfirmationDialog").should(
+              "be.visible"
+            );
+            cy.get("button[data-testid=confirmDeleteButton").click();
             // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(2000); // updating table takes some time
             if (sameNameCountBefore === 1) {
@@ -74,17 +76,17 @@ describe("CRUD products tests", () => {
   it("Edit product", () => {
     const newName = uuidv4().substring(0, 6);
     cy.navigateToProductsPage();
-    cy.get("button[data-cy=editProductButton]")
+    cy.get("button[data-testid=editProductButton]")
       .first()
       .click();
-    cy.get("form[data-cy=productDialog").should("be.visible");
-    cy.get("div[data-cy=productName] input")
+    cy.get("form[data-testid=productDialog").should("be.visible");
+    cy.get("div[data-testid=productName] input")
       .clear()
       .type(newName);
-    cy.get("button[data-cy=submitCreateProduct")
+    cy.get("button[data-testid=submitCreateProduct")
       .click()
       .then(() => {
-        cy.get("td[data-cy=productNameCell]")
+        cy.get("td[data-testid=productNameCell]")
           .first()
           .invoke("text")
           .should("equal", newName);

--- a/cypress/integration/productsTests.js
+++ b/cypress/integration/productsTests.js
@@ -19,18 +19,18 @@ describe("CRUD products tests", () => {
   // We're expecting this test to fail once pagination of tables gets implemented
   it("'Delete product' removes one row from table", () => {
     cy.navigateToProductsPage();
-    cy.get("tbody[data-testid=productsTableBody")
+    cy.get("[data-testid=productsTableBody")
       .find("tr")
       .its("length")
       .then(rowsBefore => {
-        cy.get("button[data-testid=deleteProductButton]")
+        cy.get("[data-testid=deleteProductButton]")
           .first()
           .click();
-        cy.get("div[data-testid=deleteConfirmationDialog").should("be.visible");
-        cy.get("button[data-testid=confirmDeleteButton").click();
+        cy.get("[data-testid=deleteConfirmationDialog").should("be.visible");
+        cy.get("[data-testid=confirmDeleteButton").click();
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(2000); // updating table takes some time
-        cy.get("tbody[data-testid=productsTableBody")
+        cy.get("[data-testid=productsTableBody")
           .find("tr")
           .its("length")
           .as("rowsAfter");
@@ -40,7 +40,7 @@ describe("CRUD products tests", () => {
 
   it("'Delete product' lowers count of products with same name by 1", () => {
     cy.navigateToProductsPage();
-    cy.get("td[data-testid=productNameCell]")
+    cy.get("[data-testid=productNameCell]")
       .first()
       .invoke("text")
       .as("firstProductName")
@@ -49,13 +49,13 @@ describe("CRUD products tests", () => {
           .its("length")
           .as("sameNameCountBefore")
           .then(sameNameCountBefore => {
-            cy.get("button[data-testid=deleteProductButton]")
+            cy.get("[data-testid=deleteProductButton]")
               .first()
               .click();
-            cy.get("div[data-testid=deleteConfirmationDialog").should(
+            cy.get("[data-testid=deleteConfirmationDialog").should(
               "be.visible"
             );
-            cy.get("button[data-testid=confirmDeleteButton").click();
+            cy.get("[data-testid=confirmDeleteButton").click();
             // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(2000); // updating table takes some time
             if (sameNameCountBefore === 1) {
@@ -76,17 +76,17 @@ describe("CRUD products tests", () => {
   it("Edit product", () => {
     const newName = uuidv4().substring(0, 6);
     cy.navigateToProductsPage();
-    cy.get("button[data-testid=editProductButton]")
+    cy.get("[data-testid=editProductButton]")
       .first()
       .click();
-    cy.get("form[data-testid=productDialog").should("be.visible");
-    cy.get("div[data-testid=productName] input")
+    cy.get("[data-testid=productDialog").should("be.visible");
+    cy.get("[data-testid=productName] input")
       .clear()
       .type(newName);
-    cy.get("button[data-testid=submitCreateProduct")
+    cy.get("[data-testid=submitCreateProduct")
       .click()
       .then(() => {
-        cy.get("td[data-testid=productNameCell]")
+        cy.get("[data-testid=productNameCell]")
           .first()
           .invoke("text")
           .should("equal", newName);

--- a/cypress/integration/signupOrganization.js
+++ b/cypress/integration/signupOrganization.js
@@ -16,46 +16,50 @@ describe("Add Organization", () => {
   });
 
   it("Organization name cannot be empty", () => {
-    cy.get("div[data-cy=orgNameInput] input")
+    cy.get("div[data-testid=orgNameInput] input")
       .type(`{enter}`)
       .then(() => {
-        cy.get("div[data-cy=orgNameInput]").should("be.visible"); // organization name input should be visible
+        cy.get("div[data-testid=orgNameInput]").should("be.visible"); // organization name input should be visible
       });
   });
 
   it("Password cannot be empty", () => {
-    cy.get("div[data-cy=orgNameInput] input").type(`${testOrg}{enter}`);
-    cy.get("div[data-cy=name] input").type(`${testUser}`);
-    cy.get("div[data-cy=email] input").type(`${testUser}@example.com`);
-    cy.get("button[data-cy=createUserButton")
+    cy.get("div[data-testid=orgNameInput] input").type(`${testOrg}{enter}`);
+    cy.get("div[data-testid=name] input").type(`${testUser}`);
+    cy.get("div[data-testid=email] input").type(`${testUser}@example.com`);
+    cy.get("button[data-testid=createUserButton")
       .click()
       .then(() => {
-        cy.get("button[data-cy=createUserButton").should("be.visible"); // continue button should be visible
+        cy.get("button[data-testid=createUserButton").should("be.visible"); // continue button should be visible
       });
   });
 
   it("Adds an organization confirmed by enter", () => {
-    cy.get("div[data-cy=orgNameInput] input").type(`${testOrg}{enter}`);
-    cy.get("div[data-cy=name] input").type(`${testUser}`);
-    cy.get("div[data-cy=email] input").type(`${testUser}@example.com`);
-    cy.get("div[data-cy=password] input")
+    cy.get("div[data-testid=orgNameInput] input").type(`${testOrg}{enter}`);
+    cy.get("div[data-testid=name] input").type(`${testUser}`);
+    cy.get("div[data-testid=email] input").type(`${testUser}@example.com`);
+    cy.get("div[data-testid=password] input")
       .type(`${testPwd}{enter}`)
       .then(() => {
-        cy.get("button[data-cy=createUserButton]").should("not.exist");
-        cy.get("button[data-cy=copyToClipboardButton]").should("be.visible");
+        cy.get("button[data-testid=createUserButton]").should("not.exist");
+        cy.get("button[data-testid=copyToClipboardButton]").should(
+          "be.visible"
+        );
       });
   });
 
   it("Adds an organization confirmed by submit button", () => {
-    cy.get("div[data-cy=orgNameInput] input").type(`${testOrg}_2{enter}`);
-    cy.get("div[data-cy=name] input").type(`${testUser}_2`);
-    cy.get("div[data-cy=email] input").type(`${testUser}_2@example.com`); // can't use the same mail as the previous test
-    cy.get("div[data-cy=password] input").type(`${testPwd}_2`);
-    cy.get("button[data-cy=createUserButton]")
+    cy.get("div[data-testid=orgNameInput] input").type(`${testOrg}_2{enter}`);
+    cy.get("div[data-testid=name] input").type(`${testUser}_2`);
+    cy.get("div[data-testid=email] input").type(`${testUser}_2@example.com`); // can't use the same mail as the previous test
+    cy.get("div[data-testid=password] input").type(`${testPwd}_2`);
+    cy.get("button[data-testid=createUserButton]")
       .click()
       .then(() => {
-        cy.get("button[data-cy=createUserButton]").should("not.exist");
-        cy.get("button[data-cy=copyToClipboardButton]").should("be.visible");
+        cy.get("button[data-testid=createUserButton]").should("not.exist");
+        cy.get("button[data-testid=copyToClipboardButton]").should(
+          "be.visible"
+        );
       });
   });
 });

--- a/cypress/integration/signupOrganization.js
+++ b/cypress/integration/signupOrganization.js
@@ -16,50 +16,46 @@ describe("Add Organization", () => {
   });
 
   it("Organization name cannot be empty", () => {
-    cy.get("div[data-testid=orgNameInput] input")
+    cy.get("[data-testid=orgNameInput] input")
       .type(`{enter}`)
       .then(() => {
-        cy.get("div[data-testid=orgNameInput]").should("be.visible"); // organization name input should be visible
+        cy.get("[data-testid=orgNameInput]").should("be.visible"); // organization name input should be visible
       });
   });
 
   it("Password cannot be empty", () => {
-    cy.get("div[data-testid=orgNameInput] input").type(`${testOrg}{enter}`);
-    cy.get("div[data-testid=name] input").type(`${testUser}`);
-    cy.get("div[data-testid=email] input").type(`${testUser}@example.com`);
-    cy.get("button[data-testid=createUserButton")
+    cy.get("[data-testid=orgNameInput] input").type(`${testOrg}{enter}`);
+    cy.get("[data-testid=name] input").type(`${testUser}`);
+    cy.get("[data-testid=email] input").type(`${testUser}@example.com`);
+    cy.get("[data-testid=createUserButton")
       .click()
       .then(() => {
-        cy.get("button[data-testid=createUserButton").should("be.visible"); // continue button should be visible
+        cy.get("[data-testid=createUserButton").should("be.visible"); // continue button should be visible
       });
   });
 
   it("Adds an organization confirmed by enter", () => {
-    cy.get("div[data-testid=orgNameInput] input").type(`${testOrg}{enter}`);
-    cy.get("div[data-testid=name] input").type(`${testUser}`);
-    cy.get("div[data-testid=email] input").type(`${testUser}@example.com`);
-    cy.get("div[data-testid=password] input")
+    cy.get("[data-testid=orgNameInput] input").type(`${testOrg}{enter}`);
+    cy.get("[data-testid=name] input").type(`${testUser}`);
+    cy.get("[data-testid=email] input").type(`${testUser}@example.com`);
+    cy.get("[data-testid=password] input")
       .type(`${testPwd}{enter}`)
       .then(() => {
-        cy.get("button[data-testid=createUserButton]").should("not.exist");
-        cy.get("button[data-testid=copyToClipboardButton]").should(
-          "be.visible"
-        );
+        cy.get("[data-testid=createUserButton]").should("not.exist");
+        cy.get("[data-testid=copyToClipboardButton]").should("be.visible");
       });
   });
 
   it("Adds an organization confirmed by submit button", () => {
-    cy.get("div[data-testid=orgNameInput] input").type(`${testOrg}_2{enter}`);
-    cy.get("div[data-testid=name] input").type(`${testUser}_2`);
-    cy.get("div[data-testid=email] input").type(`${testUser}_2@example.com`); // can't use the same mail as the previous test
-    cy.get("div[data-testid=password] input").type(`${testPwd}_2`);
-    cy.get("button[data-testid=createUserButton]")
+    cy.get("[data-testid=orgNameInput] input").type(`${testOrg}_2{enter}`);
+    cy.get("[data-testid=name] input").type(`${testUser}_2`);
+    cy.get("[data-testid=email] input").type(`${testUser}_2@example.com`); // can't use the same mail as the previous test
+    cy.get("[data-testid=password] input").type(`${testPwd}_2`);
+    cy.get("[data-testid=createUserButton]")
       .click()
       .then(() => {
-        cy.get("button[data-testid=createUserButton]").should("not.exist");
-        cy.get("button[data-testid=copyToClipboardButton]").should(
-          "be.visible"
-        );
+        cy.get("[data-testid=createUserButton]").should("not.exist");
+        cy.get("[data-testid=copyToClipboardButton]").should("be.visible");
       });
   });
 });

--- a/cypress/integration/signupOrganization.js
+++ b/cypress/integration/signupOrganization.js
@@ -16,46 +16,46 @@ describe("Add Organization", () => {
   });
 
   it("Organization name cannot be empty", () => {
-    cy.get("[data-testid=orgNameInput] input")
+    cy.getInputContainedByTestId("orgNameInput")
       .type(`{enter}`)
       .then(() => {
-        cy.get("[data-testid=orgNameInput]").should("be.visible"); // organization name input should be visible
+        cy.getByTestId("orgNameInput").should("be.visible"); // organization name input should be visible
       });
   });
 
   it("Password cannot be empty", () => {
-    cy.get("[data-testid=orgNameInput] input").type(`${testOrg}{enter}`);
-    cy.get("[data-testid=name] input").type(`${testUser}`);
-    cy.get("[data-testid=email] input").type(`${testUser}@example.com`);
-    cy.get("[data-testid=createUserButton")
+    cy.getInputContainedByTestId("orgNameInput").type(`${testOrg}{enter}`);
+    cy.getInputContainedByTestId("name").type(`${testUser}`);
+    cy.getInputContainedByTestId("email").type(`${testUser}@example.com`);
+    cy.getByTestId("createUserButton")
       .click()
       .then(() => {
-        cy.get("[data-testid=createUserButton").should("be.visible"); // continue button should be visible
+        cy.getByTestId("createUserButton").should("be.visible"); // continue button should be visible
       });
   });
 
   it("Adds an organization confirmed by enter", () => {
-    cy.get("[data-testid=orgNameInput] input").type(`${testOrg}{enter}`);
-    cy.get("[data-testid=name] input").type(`${testUser}`);
-    cy.get("[data-testid=email] input").type(`${testUser}@example.com`);
-    cy.get("[data-testid=password] input")
+    cy.getInputContainedByTestId("orgNameInput").type(`${testOrg}{enter}`);
+    cy.getInputContainedByTestId("name").type(`${testUser}`);
+    cy.getInputContainedByTestId("email").type(`${testUser}@example.com`);
+    cy.getInputContainedByTestId("password")
       .type(`${testPwd}{enter}`)
       .then(() => {
-        cy.get("[data-testid=createUserButton]").should("not.exist");
-        cy.get("[data-testid=copyToClipboardButton]").should("be.visible");
+        cy.getByTestId("createUserButton").should("not.exist");
+        cy.getByTestId("copyToClipboardButton").should("be.visible");
       });
   });
 
   it("Adds an organization confirmed by submit button", () => {
-    cy.get("[data-testid=orgNameInput] input").type(`${testOrg}_2{enter}`);
-    cy.get("[data-testid=name] input").type(`${testUser}_2`);
-    cy.get("[data-testid=email] input").type(`${testUser}_2@example.com`); // can't use the same mail as the previous test
-    cy.get("[data-testid=password] input").type(`${testPwd}_2`);
-    cy.get("[data-testid=createUserButton]")
+    cy.getInputContainedByTestId("orgNameInput").type(`${testOrg}_2{enter}`);
+    cy.getInputContainedByTestId("name").type(`${testUser}_2`);
+    cy.getInputContainedByTestId("email").type(`${testUser}_2@example.com`); // can't use the same mail as the previous test
+    cy.getInputContainedByTestId("password").type(`${testPwd}_2`);
+    cy.getByTestId("createUserButton")
       .click()
       .then(() => {
-        cy.get("[data-testid=createUserButton]").should("not.exist");
-        cy.get("[data-testid=copyToClipboardButton]").should("be.visible");
+        cy.getByTestId("createUserButton").should("not.exist");
+        cy.getByTestId("copyToClipboardButton").should("be.visible");
       });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,25 +27,25 @@ import uuidv4 from "uuid/v4";
 
 Cypress.Commands.add("reLogin", (userMail, userPassword) => {
   cy.visit("/signout");
-  cy.get("div[data-testid=email] input").type(`${userMail}`);
-  cy.get("div[data-testid=password] input").type(`${userPassword}`);
-  cy.get("button[data-testid=signInButton]").click();
+  cy.get("[data-testid=email] input").type(`${userMail}`);
+  cy.get("[data-testid=password] input").type(`${userPassword}`);
+  cy.get("[data-testid=signInButton]").click();
   cy.location("pathname", { timeout: 10000 }).should("not.include", "/signin");
 });
 
 Cypress.Commands.add("openAppDrawer", () => {
-  cy.get("button[data-ctestidy=appDrawerOpener]").should("be.visible");
+  cy.get("[data-testid=appDrawerOpener]").should("be.visible");
   cy.get("body").then($body => {
-    if ($body.find("button[data-testid=appDrawerOpener]").length > 0) {
-      cy.get("button[data-testid=appDrawerOpener]")
+    if ($body.find("[data-testid=appDrawerOpener]").length > 0) {
+      cy.get("[data-testid=appDrawerOpener]")
         .click()
         .then(() => {
-          cy.get("div[data-testid=appDrawerDiv]")
+          cy.get("[data-testid=appDrawerDiv]")
             .last()
             .should("be.visible");
         });
     } else {
-      cy.get("div[data-testid=appDrawerDiv]")
+      cy.get("[data-testid=appDrawerDiv]")
         .last()
         .should("be.visible");
     }
@@ -54,21 +54,21 @@ Cypress.Commands.add("openAppDrawer", () => {
 
 Cypress.Commands.add("navigateToChangePasswordForm", () => {
   cy.openAppDrawer();
-  cy.get("a[data-testid=changePasswordDrawerButton]")
+  cy.get("[data-testid=changePasswordDrawerButton]")
     .last()
     .click();
 });
 
 Cypress.Commands.add("navigateToProductsPage", () => {
   cy.openAppDrawer();
-  cy.get("a[data-testid=productsDrawerButton]")
+  cy.get("[data-testid=productsDrawerButton]")
     .last()
     .click();
 });
 
 Cypress.Commands.add("navigateToInvitePage", () => {
   cy.openAppDrawer();
-  cy.get("a[data-testid=inviteDrawerButton]")
+  cy.get("[data-testid=inviteDrawerButton]")
     .last()
     .click();
 });
@@ -76,16 +76,16 @@ Cypress.Commands.add("navigateToInvitePage", () => {
 // 'Delete product' helper function
 Cypress.Commands.add("createTestProduct", () => {
   const productName = uuidv4().substring(0, 6);
-  cy.get("button[data-testid=addProductButton]").click();
-  cy.get("div[data-testid=selectCategory]").click();
+  cy.get("[data-testid=addProductButton]").click();
+  cy.get("[data-testid=selectCategory]").click();
   cy.get("li[id=category]")
     .first()
     .click();
-  cy.get("div[data-testid=productName] input").type(`${productName}`);
-  cy.get("button[data-testid=submitCreateProduct").click({ timeout: 10000 });
+  cy.get("[data-testid=productName] input").type(`${productName}`);
+  cy.get("[data-testid=submitCreateProduct").click({ timeout: 10000 });
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(2000); // give table some time to update (without wait or doing this in click().then({}) doesn't find new row at all)
-  cy.get("td[data-testid=productNameCell]")
+  cy.get("[data-testid=productNameCell]")
     .contains(`${productName}`)
     .should("exist"); // cell with product name should be visible
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,27 +25,37 @@ import uuidv4 from "uuid/v4";
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
+Cypress.Commands.add("getByTestId", testId =>
+  cy.get(`[data-testid=${testId}]`)
+);
+Cypress.Commands.add("getInputContainedByTestId", testId =>
+  cy.get(`[data-testid=${testId}] input`)
+);
+Cypress.Commands.add("getTextAreaContainedByTestId", testId =>
+  cy.get(`[data-testid=${testId}] textarea`)
+);
+
 Cypress.Commands.add("reLogin", (userMail, userPassword) => {
   cy.visit("/signout");
-  cy.get("[data-testid=email] input").type(`${userMail}`);
-  cy.get("[data-testid=password] input").type(`${userPassword}`);
-  cy.get("[data-testid=signInButton]").click();
+  cy.getInputContainedByTestId("email").type(`${userMail}`);
+  cy.getInputContainedByTestId("password").type(`${userPassword}`);
+  cy.getByTestId("signInButton").click();
   cy.location("pathname", { timeout: 10000 }).should("not.include", "/signin");
 });
 
 Cypress.Commands.add("openAppDrawer", () => {
-  cy.get("[data-testid=appDrawerOpener]").should("be.visible");
+  cy.getByTestId("appDrawerOpener").should("be.visible");
   cy.get("body").then($body => {
     if ($body.find("[data-testid=appDrawerOpener]").length > 0) {
-      cy.get("[data-testid=appDrawerOpener]")
+      cy.getByTestId("appDrawerOpener")
         .click()
         .then(() => {
-          cy.get("[data-testid=appDrawerDiv]")
+          cy.getByTestId("appDrawerDiv")
             .last()
             .should("be.visible");
         });
     } else {
-      cy.get("[data-testid=appDrawerDiv]")
+      cy.getByTestId("appDrawerDiv")
         .last()
         .should("be.visible");
     }
@@ -54,21 +64,21 @@ Cypress.Commands.add("openAppDrawer", () => {
 
 Cypress.Commands.add("navigateToChangePasswordForm", () => {
   cy.openAppDrawer();
-  cy.get("[data-testid=changePasswordDrawerButton]")
+  cy.getByTestId("changePasswordDrawerButton")
     .last()
     .click();
 });
 
 Cypress.Commands.add("navigateToProductsPage", () => {
   cy.openAppDrawer();
-  cy.get("[data-testid=productsDrawerButton]")
+  cy.getByTestId("productsDrawerButton")
     .last()
     .click();
 });
 
 Cypress.Commands.add("navigateToInvitePage", () => {
   cy.openAppDrawer();
-  cy.get("[data-testid=inviteDrawerButton]")
+  cy.getByTestId("inviteDrawerButton")
     .last()
     .click();
 });
@@ -76,16 +86,16 @@ Cypress.Commands.add("navigateToInvitePage", () => {
 // 'Delete product' helper function
 Cypress.Commands.add("createTestProduct", () => {
   const productName = uuidv4().substring(0, 6);
-  cy.get("[data-testid=addProductButton]").click();
-  cy.get("[data-testid=selectCategory]").click();
+  cy.getByTestId("addProductButton").click();
+  cy.getByTestId("selectCategory").click();
   cy.get("li[id=category]")
     .first()
     .click();
-  cy.get("[data-testid=productName] input").type(`${productName}`);
-  cy.get("[data-testid=submitCreateProduct").click({ timeout: 10000 });
+  cy.getInputContainedByTestId("productName").type(`${productName}`);
+  cy.getByTestId("submitCreateProduct").click({ timeout: 10000 });
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(2000); // give table some time to update (without wait or doing this in click().then({}) doesn't find new row at all)
-  cy.get("[data-testid=productNameCell]")
+  cy.getByTestId("productNameCell")
     .contains(`${productName}`)
     .should("exist"); // cell with product name should be visible
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -27,25 +27,25 @@ import uuidv4 from "uuid/v4";
 
 Cypress.Commands.add("reLogin", (userMail, userPassword) => {
   cy.visit("/signout");
-  cy.get("div[data-cy=email] input").type(`${userMail}`);
-  cy.get("div[data-cy=password] input").type(`${userPassword}`);
-  cy.get("button[data-cy=signInButton]").click();
+  cy.get("div[data-testid=email] input").type(`${userMail}`);
+  cy.get("div[data-testid=password] input").type(`${userPassword}`);
+  cy.get("button[data-testid=signInButton]").click();
   cy.location("pathname", { timeout: 10000 }).should("not.include", "/signin");
 });
 
 Cypress.Commands.add("openAppDrawer", () => {
-  cy.get("button[data-cy=appDrawerOpener]").should("be.visible");
+  cy.get("button[data-ctestidy=appDrawerOpener]").should("be.visible");
   cy.get("body").then($body => {
-    if ($body.find("button[data-cy=appDrawerOpener]").length > 0) {
-      cy.get("button[data-cy=appDrawerOpener]")
+    if ($body.find("button[data-testid=appDrawerOpener]").length > 0) {
+      cy.get("button[data-testid=appDrawerOpener]")
         .click()
         .then(() => {
-          cy.get("div[data-cy=appDrawerDiv]")
+          cy.get("div[data-testid=appDrawerDiv]")
             .last()
             .should("be.visible");
         });
     } else {
-      cy.get("div[data-cy=appDrawerDiv]")
+      cy.get("div[data-testid=appDrawerDiv]")
         .last()
         .should("be.visible");
     }
@@ -54,21 +54,21 @@ Cypress.Commands.add("openAppDrawer", () => {
 
 Cypress.Commands.add("navigateToChangePasswordForm", () => {
   cy.openAppDrawer();
-  cy.get("a[data-cy=changePasswordDrawerButton]")
+  cy.get("a[data-testid=changePasswordDrawerButton]")
     .last()
     .click();
 });
 
 Cypress.Commands.add("navigateToProductsPage", () => {
   cy.openAppDrawer();
-  cy.get("a[data-cy=productsDrawerButton]")
+  cy.get("a[data-testid=productsDrawerButton]")
     .last()
     .click();
 });
 
 Cypress.Commands.add("navigateToInvitePage", () => {
   cy.openAppDrawer();
-  cy.get("a[data-cy=inviteDrawerButton]")
+  cy.get("a[data-testid=inviteDrawerButton]")
     .last()
     .click();
 });
@@ -76,16 +76,16 @@ Cypress.Commands.add("navigateToInvitePage", () => {
 // 'Delete product' helper function
 Cypress.Commands.add("createTestProduct", () => {
   const productName = uuidv4().substring(0, 6);
-  cy.get("button[data-cy=addProductButton]").click();
-  cy.get("div[data-cy=selectCategory]").click();
+  cy.get("button[data-testid=addProductButton]").click();
+  cy.get("div[data-testid=selectCategory]").click();
   cy.get("li[id=category]")
     .first()
     .click();
-  cy.get("div[data-cy=productName] input").type(`${productName}`);
-  cy.get("button[data-cy=submitCreateProduct").click({ timeout: 10000 });
+  cy.get("div[data-testid=productName] input").type(`${productName}`);
+  cy.get("button[data-testid=submitCreateProduct").click({ timeout: 10000 });
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(2000); // give table some time to update (without wait or doing this in click().then({}) doesn't find new row at all)
-  cy.get("td[data-cy=productNameCell]")
+  cy.get("td[data-testid=productNameCell]")
     .contains(`${productName}`)
     .should("exist"); // cell with product name should be visible
 });

--- a/src/components/DeleteButton.jsx
+++ b/src/components/DeleteButton.jsx
@@ -11,7 +11,7 @@ const DeleteButton = ({ confirmationText, onDelete }) => {
       <IconButton
         onClick={() => setDialogOpen(true)}
         aria-label="Delete"
-        data-cy="deleteProductButton"
+        data-testid="deleteProductButton"
       >
         <DeleteIcon />
       </IconButton>

--- a/src/components/DeleteConfirmationDialog.jsx
+++ b/src/components/DeleteConfirmationDialog.jsx
@@ -13,7 +13,7 @@ const ConfirmDeleteAlert = ({ open, onCancel, onConfirm, children }) => {
       onClose={onCancel}
       aria-labelledby="alert-dialog-title"
       aria-describedby="alert-dialog-description"
-      data-cy="deleteConfirmationDialog"
+      data-testid="deleteConfirmationDialog"
     >
       <DialogTitle id="alert-dialog-title">Are you sure?</DialogTitle>
       <DialogContent>
@@ -29,7 +29,7 @@ const ConfirmDeleteAlert = ({ open, onCancel, onConfirm, children }) => {
           onClick={onConfirm}
           color="secondary"
           variant="contained"
-          data-cy="confirmDeleteButton"
+          data-testid="confirmDeleteButton"
           autoFocus
         >
           Delete

--- a/src/components/SubmitButton.jsx
+++ b/src/components/SubmitButton.jsx
@@ -39,7 +39,7 @@ export const SubmitButton = ({
       variant={isInDialog ? "text" : "contained"}
       color="primary"
       type="submit"
-      data-cy={dataCyTag}
+      data-testid={dataCyTag}
       disabled={isSubmitting}
       {...props}
     >

--- a/src/modules/auth/components/AppDrawerAuth.jsx
+++ b/src/modules/auth/components/AppDrawerAuth.jsx
@@ -17,7 +17,7 @@ const AppDrawerAuth = ({ user }) => {
     <List>
       <ListItem>
         <ListItemText
-          data-cy="signedInAsLabel"
+          data-testid="signedInAsLabel"
           secondary={`Signed in as ${displayName}`}
         />
       </ListItem>
@@ -27,7 +27,7 @@ const AppDrawerAuth = ({ user }) => {
       <ListItem
         component={Link}
         to="/invite"
-        data-cy="inviteDrawerButton"
+        data-testid="inviteDrawerButton"
         button
       >
         <ListItemText primary="Invite people" />
@@ -35,7 +35,7 @@ const AppDrawerAuth = ({ user }) => {
       <ListItem
         component={Link}
         to="/password"
-        data-cy="changePasswordDrawerButton"
+        data-testid="changePasswordDrawerButton"
         button
       >
         <ListItemText primary="Change password" />
@@ -43,7 +43,7 @@ const AppDrawerAuth = ({ user }) => {
       <ListItem
         component={Link}
         to="/signout"
-        data-cy="signoutDrawerButton"
+        data-testid="signoutDrawerButton"
         button
       >
         <ListItemText primary="Sign out" />

--- a/src/modules/auth/components/PasswordChangeForm.jsx
+++ b/src/modules/auth/components/PasswordChangeForm.jsx
@@ -33,7 +33,7 @@ const PasswordChangeForm = ({ user, userPasswordChange }) => {
   return (
     <form onSubmit={handleSubmit}>
       {hasSubmittedForm && !user.error ? (
-        <Typography color="primary" data-cy="pwdChangeConfirmation">
+        <Typography color="primary" data-testid="pwdChangeConfirmation">
           Your password has been updated successfully.
         </Typography>
       ) : null}
@@ -45,7 +45,7 @@ const PasswordChangeForm = ({ user, userPasswordChange }) => {
         fullWidth
         margin="normal"
         {...attachValidation("currentPassword")}
-        data-cy="currentPassword"
+        data-testid="currentPassword"
       />
       <TextField
         type="password"
@@ -54,7 +54,7 @@ const PasswordChangeForm = ({ user, userPasswordChange }) => {
         fullWidth
         margin="normal"
         {...attachValidation("newPassword")}
-        data-cy="newPassword"
+        data-testid="newPassword"
       />
       <TextField
         type="password"
@@ -63,7 +63,7 @@ const PasswordChangeForm = ({ user, userPasswordChange }) => {
         fullWidth
         margin="normal"
         {...attachValidation("confirmedPassword")}
-        data-cy="confirmedPassword"
+        data-testid="confirmedPassword"
       />
       <SubmitButton isSubmitting={user.isUpdating}>
         Update Password

--- a/src/modules/auth/components/SignInForm.jsx
+++ b/src/modules/auth/components/SignInForm.jsx
@@ -33,7 +33,7 @@ const SignInForm = ({ serverError, loading, userSignIn }) => {
         fullWidth
         margin="normal"
         {...attachValidation("email")}
-        data-cy="email"
+        data-testid="email"
       />
       <TextField
         id="password"
@@ -43,7 +43,7 @@ const SignInForm = ({ serverError, loading, userSignIn }) => {
         fullWidth
         margin="normal"
         {...attachValidation("password")}
-        data-cy="password"
+        data-testid="password"
       />
       <SubmitButton isSubmitting={loading || false} dataCyTag="signInButton">
         Sign In

--- a/src/modules/boxes/components/AddBoxDone.jsx
+++ b/src/modules/boxes/components/AddBoxDone.jsx
@@ -15,7 +15,7 @@ const AddBoxDone = ({ box, selectedProduct, onClose, onReset }) => (
     />
     <DialogContent>
       <br />
-      <Typography variant="h6" data-cy="boxCreatedLabel" gutterBottom>
+      <Typography variant="h6" data-testid="boxCreatedLabel" gutterBottom>
         Box created
       </Typography>
       <Typography gutterBottom>Write on the label:</Typography>
@@ -23,7 +23,11 @@ const AddBoxDone = ({ box, selectedProduct, onClose, onReset }) => (
       <Typography variant="h6" gutterBottom>
         <strong>{box.humanID}</strong>
       </Typography>
-      <Typography variant="h6" gutterBottom data-cy="boxCreatedQuantityLabel">
+      <Typography
+        variant="h6"
+        gutterBottom
+        data-testid="boxCreatedQuantityLabel"
+      >
         <strong>{box.quantity}x</strong>
       </Typography>
       <Typography variant="h6" gutterBottom>
@@ -34,7 +38,7 @@ const AddBoxDone = ({ box, selectedProduct, onClose, onReset }) => (
         variant="contained"
         onClick={onReset}
         color="primary"
-        data-cy="createAnotherBoxButton"
+        data-testid="createAnotherBoxButton"
       >
         Create another box
       </Button>

--- a/src/modules/boxes/components/AddBoxForm.jsx
+++ b/src/modules/boxes/components/AddBoxForm.jsx
@@ -27,7 +27,7 @@ const AddBoxForm = ({ onClose, onSubmit, products, serverError }) => {
     handleValidation
   );
   return (
-    <form onSubmit={handleSubmit} data-cy="boxForm">
+    <form onSubmit={handleSubmit} data-testid="boxForm">
       <DialogToolbar
         title="New box"
         onClose={onClose}
@@ -47,14 +47,14 @@ const AddBoxForm = ({ onClose, onSubmit, products, serverError }) => {
               fullWidth
               autoFocus
               margin="dense"
-              data-cy="selectProduct"
+              data-testid="selectProduct"
               {...attachValidation("product")}
             >
               {products.map(({ id, name, category }) => (
                 <MenuItem
                   key={id}
                   value={JSON.stringify({ id, category, name })}
-                  data-cy="productDropdownItem"
+                  data-testid="productDropdownItem"
                 >
                   {category} / {name}
                 </MenuItem>
@@ -68,7 +68,7 @@ const AddBoxForm = ({ onClose, onSubmit, products, serverError }) => {
               margin="dense"
               inputProps={{ pattern: "[0-9]*", inputMode: "numeric" }}
               {...attachValidation("quantity")}
-              data-cy="quantity"
+              data-testid="quantity"
             />
             <TextField
               label="Comments"
@@ -78,7 +78,7 @@ const AddBoxForm = ({ onClose, onSubmit, products, serverError }) => {
               fullWidth
               margin="dense"
               {...attachValidation("comment")}
-              data-cy="comment"
+              data-testid="comment"
             />
           </div>
         ) : (

--- a/src/modules/layout/components/AppDrawer.jsx
+++ b/src/modules/layout/components/AppDrawer.jsx
@@ -55,7 +55,7 @@ const AppDrawer = ({
   onOpen
 }) => {
   const drawer = (
-    <div className={classes.nav} data-cy="appDrawerDiv">
+    <div className={classes.nav} data-testid="appDrawerDiv">
       <div className={classes.toolbarIe11}>
         <div className={classes.toolbar}>
           <Link className={classes.title} to="/" onClick={onClose}>
@@ -75,7 +75,7 @@ const AppDrawer = ({
           component={Link}
           to="/boxes"
           onClick={onClose}
-          data-cy="boxesDrawerButton"
+          data-testid="boxesDrawerButton"
           button
         >
           <ListItemText primary="Find boxes" />
@@ -84,7 +84,7 @@ const AppDrawer = ({
           component={Link}
           to="/products"
           onClick={onClose}
-          data-cy="productsDrawerButton"
+          data-testid="productsDrawerButton"
           button
         >
           <ListItemText primary="Manage products" />
@@ -93,7 +93,7 @@ const AppDrawer = ({
           component={Link}
           to="/create-labels"
           onClick={onClose}
-          data-cy="labelsDrawerButton"
+          data-testid="labelsDrawerButton"
           button
         >
           <ListItemText primary="Create labels" />

--- a/src/modules/layout/components/AppFrame.jsx
+++ b/src/modules/layout/components/AppFrame.jsx
@@ -75,7 +75,7 @@ const AppFrame = ({ children, classes, title }) => {
             aria-label="open drawer"
             onClick={handleDrawerOpen}
             className={classes.hamburger}
-            data-cy="appDrawerOpener"
+            data-testid="appDrawerOpener"
           >
             <MenuIcon />
           </IconButton>

--- a/src/modules/layout/pages/DashboardPage.jsx
+++ b/src/modules/layout/pages/DashboardPage.jsx
@@ -48,7 +48,7 @@ const DashboardPage = ({ classes }) => {
             <FormattedMessage {...messages.headline} />
           </Typography>
           <Button
-            data-cy="makeBoxButton"
+            data-testid="makeBoxButton"
             variant="contained"
             color="secondary"
             onClick={() => setAddBoxDialogOpen(true)}
@@ -58,7 +58,7 @@ const DashboardPage = ({ classes }) => {
           <br />
           <br />
           <Button
-            data-cy="findBoxesButton"
+            data-testid="findBoxesButton"
             variant="contained"
             color="secondary"
             component={Link}

--- a/src/modules/products/components/ProductDialog.jsx
+++ b/src/modules/products/components/ProductDialog.jsx
@@ -47,7 +47,7 @@ const ProductDialog = ({
       fullWidth
       TransitionComponent={Transition}
     >
-      <form onSubmit={handleSubmit} data-cy="productDialog">
+      <form onSubmit={handleSubmit} data-testid="productDialog">
         <DialogToolbar
           title={productToEdit ? "Edit Product" : "Add Product"}
           onClose={onClose}
@@ -64,7 +64,7 @@ const ProductDialog = ({
             select
             fullWidth
             margin="dense"
-            data-cy="selectCategory"
+            data-testid="selectCategory"
             {...attachValidation("category")}
           >
             {CATEGORIES.map(category => (
@@ -81,7 +81,7 @@ const ProductDialog = ({
             helperText="Enter a name, like “T-Shirt” or “Socks”. Don’t reuse the category
             name here."
             {...attachValidation("name")}
-            data-cy="productName"
+            data-testid="productName"
           />
         </DialogContent>
       </form>

--- a/src/modules/products/containers/ProductTable.jsx
+++ b/src/modules/products/containers/ProductTable.jsx
@@ -59,18 +59,18 @@ const ProductTable = ({
               <TableCell padding="dense" />
             </TableRow>
           </TableHead>
-          <TableBody data-cy="productsTableBody">
+          <TableBody data-testid="productsTableBody">
             {data.map(product => (
               <TableRow key={product.id}>
                 <TableCell padding="dense">{product.category}</TableCell>
-                <TableCell padding="dense" data-cy="productNameCell">
+                <TableCell padding="dense" data-testid="productNameCell">
                   {product.name}
                 </TableCell>
                 <TableCell padding="dense">
                   <IconButton
                     onClick={() => setSelectedProduct(product)}
                     aria-label="Edit"
-                    data-cy="editProductButton"
+                    data-testid="editProductButton"
                   >
                     <EditIcon />
                   </IconButton>

--- a/src/modules/products/pages/ProductsPage.jsx
+++ b/src/modules/products/pages/ProductsPage.jsx
@@ -19,7 +19,7 @@ const ProductsPage = () => {
         <Paper>
           <Toolbar>
             <Button
-              data-cy="addProductButton"
+              data-testid="addProductButton"
               color="primary"
               onClick={handleDialogOpen}
             >

--- a/src/modules/signup/components/CreateOrganizationForm.jsx
+++ b/src/modules/signup/components/CreateOrganizationForm.jsx
@@ -19,7 +19,7 @@ const CreateOrganizationForm = ({ onSubmit }) => {
   return (
     <form onSubmit={handleSubmit}>
       <TextField
-        data-cy="orgNameInput"
+        data-testid="orgNameInput"
         type="text"
         label="What’s the name of your organization?"
         name="name"

--- a/src/modules/signup/components/SignUpForm.jsx
+++ b/src/modules/signup/components/SignUpForm.jsx
@@ -37,7 +37,7 @@ const SignUpForm = ({
         fullWidth
         margin="normal"
         {...attachValidation("name")}
-        data-cy="name"
+        data-testid="name"
       />
       <TextField
         type="email"
@@ -46,7 +46,7 @@ const SignUpForm = ({
         fullWidth
         margin="normal"
         {...attachValidation("email")}
-        data-cy="email"
+        data-testid="email"
       />
       <TextField
         type="password"
@@ -55,7 +55,7 @@ const SignUpForm = ({
         fullWidth
         margin="normal"
         {...attachValidation("password")}
-        data-cy="password"
+        data-testid="password"
       />
       <SubmitButton dataCyTag="createUserButton" isSubmitting={isSubmitting}>
         {submitButtonText}

--- a/src/modules/signup/containers/InviteLink.jsx
+++ b/src/modules/signup/containers/InviteLink.jsx
@@ -44,7 +44,7 @@ const InviteLink = ({ user, children }) => {
         text={inviteData.inviteLink}
         onCopy={() => setSnackbarOpen(true)}
       >
-        <Button color="primary" data-cy="copyToClipboardButton">
+        <Button color="primary" data-testid="copyToClipboardButton">
           Copy to clipboard
         </Button>
       </CopyToClipboard>

--- a/src/modules/signup/pages/HomePage.jsx
+++ b/src/modules/signup/pages/HomePage.jsx
@@ -56,7 +56,7 @@ const HomePage = ({ classes }) => (
         <div className={classes.logo}>Boxwise</div>
         <div className={classes.login}>
           <Typography>
-            <Link className={classes.link} to="/signin" data-cy="loginLink">
+            <Link className={classes.link} to="/signin" data-testid="loginLink">
               Login or sign up
             </Link>
           </Typography>


### PR DESCRIPTION
Switch data-cy attributes to data-testid - this is what react-testing-library uses (which we're adopting in https://github.com/boxwise/boxwise/pull/494) as their attributes to identify elements, and I think it makes sense to align. 

Cypress mentions data-testid as a ‘standard’ attribute too (https://docs.cypress.io/guides/references/best-practices.html#article).

Also noticed some accidental typos in the selectors (though they still seemed to work?!) so have pulled these out into a helper.